### PR TITLE
chore: pin Node version via Volta

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,9 @@
     "typescript-eslint": "^8.34.1",
     "vite": "^7.0.0",
     "wrangler": "^4.45.3"
+  },
+  "volta": {
+    "node": "20.17.0",
+    "npm": "10.8.2"
   }
 }


### PR DESCRIPTION
## Summary
- package.json に Volta 向けの node/npm バージョンを追加
- ローカル実行環境のバージョンをプロジェクトで固定

## Changes
- Volta ブロックで Node 20.17.0 と npm 10.8.2 を指定

## Test plan
- [x] 型チェック通過
- [x] Lint通過
- [x] テスト通過
- [x] ビルド成功

🤖 Generated with [Codex CLI](https://openai.com/codex)