### PR TITLE
improve: 初回操作ヒントでUXを改善する

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import UI from "./components/UI";
 import "./App.css";
 import { SIMULATED_SECONDS_PER_REAL_SECOND } from "./constants/core";
 import { useWindDirection } from "./hooks/useWindDirection";
+import { useUxHints } from "./hooks/useUxHints";
 
 // 3Dモデルのpreload
 import { preloadModel } from "./hooks/useModelScene";
@@ -96,6 +97,7 @@ type AppStyle = React.CSSProperties & { "--app-background-color"?: string };
 const AppContent = () => {
   const isDay = useDayPeriod();
   const windDirection = useWindDirection();
+  const uxHints = useUxHints();
   const [assetsLoaded, setAssetsLoaded] = useState(false);
   const [minDelayElapsed, setMinDelayElapsed] = useState(false);
   const [loadingProgress, setLoadingProgress] = useState(0);
@@ -193,10 +195,14 @@ const AppContent = () => {
             <PottedPlant />
             <Rocks />
             <BubbleEffect />
-            <MemoizedWaterSurface />
+            <MemoizedWaterSurface onInteract={uxHints.markWaterRippled} />
             <MemoizedSundialGnomon />
             <MemoizedSundialBase />
-            <MemoizedDriftingBottle position={[-3, 8.2, 2]} />
+            <MemoizedDriftingBottle
+              position={[-3, 8.2, 2]}
+              onMessageRead={uxHints.markBottleOpened}
+              showHint={!isLoading && uxHints.shouldShowBottleHint}
+            />
             <MemoizedParticleLayerInstanced />
             <MemoizedClouds timeScale={SIMULATED_SECONDS_PER_REAL_SECOND / 60} />
 
@@ -211,7 +217,16 @@ const AppContent = () => {
         </Canvas>
         {/* パフォーマンスモニター - 表示（Canvas外） - ローディング完了後のみ表示 */}
         {PERFORMANCE_MONITOR && !isLoading && <PerformanceMonitorDisplay enabled={PERFORMANCE_MONITOR} />}
-        <UI />
+        <UI
+          showHints={!isLoading && uxHints.showHints}
+          showUiHint={!isLoading && uxHints.shouldShowUiHint}
+          showWaterHint={!isLoading && uxHints.shouldShowWaterHint}
+          hintProgress={uxHints.progress}
+          onDismissHints={uxHints.dismissHints}
+          onReopenHints={!isLoading ? uxHints.reopenHints : undefined}
+          onPanelOpened={uxHints.markPanelOpened}
+          onAmbientToggle={uxHints.markAmbientToggled}
+        />
         {/* 風向きコンパス - ローディング完了後のみ表示 */}
         {!isLoading && <MemoizedWindDirectionDisplay windDirection={windDirection} />}
       </div>

--- a/src/components/DriftingBottle/index.tsx
+++ b/src/components/DriftingBottle/index.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
+import { Html } from "@react-three/drei";
 import { fetchDailyMessage } from "../../utils/dailyMessage";
 import { useBottleAnimation } from "../../hooks/useBottleAnimation";
+import { useIsMobile } from "@/hooks/useIsMobile";
 import { BottleModel } from "./BottleModel";
 import { MessageCard } from "./MessageCard";
 
@@ -10,6 +12,8 @@ interface DriftingBottleProps {
   position: [number, number, number];
   /** メッセージが読まれた時のコールバック */
   onMessageRead?: () => void;
+  /** 初回導線ヒントの表示 */
+  showHint?: boolean;
 }
 
 /**
@@ -20,12 +24,14 @@ interface DriftingBottleProps {
 export const DriftingBottle = ({
   position,
   onMessageRead,
+  showHint = false,
 }: DriftingBottleProps) => {
   const [showMessage, setShowMessage] = useState(false);
   const [hovered, setHovered] = useState(false);
   const [currentMessage, setCurrentMessage] = useState("");
   const [currentSender, setCurrentSender] = useState("");
   const [dailyMessageFetched, setDailyMessageFetched] = useState(false);
+  const isMobile = useIsMobile();
 
   const bottleRef = useBottleAnimation(position);
 
@@ -70,6 +76,28 @@ export const DriftingBottle = ({
       onPointerOut={() => setHovered(false)}
     >
       <BottleModel hovered={hovered} />
+      {showHint && !showMessage && (
+        <Html position={[0, 1.3, 0]} center distanceFactor={10} style={{ pointerEvents: "none" }}>
+          <div
+            style={{
+              padding: isMobile ? "8px 12px" : "10px 14px",
+              border: "1px solid rgba(255, 255, 255, 0.22)",
+              borderRadius: "999px",
+              background: "rgba(12, 20, 30, 0.56)",
+              backdropFilter: "blur(12px)",
+              WebkitBackdropFilter: "blur(12px)",
+              color: "rgba(255, 255, 255, 0.92)",
+              boxShadow: "0 10px 24px rgba(0, 0, 0, 0.28)",
+              fontFamily: "'Noto Serif JP', serif",
+              fontSize: isMobile ? "12px" : "13px",
+              letterSpacing: "0.04em",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {isMobile ? "瓶をタップして便りを読む" : "瓶をクリックして便りを読む"}
+          </div>
+        </Html>
+      )}
       {showMessage && (
         <MessageCard
           message={currentMessage}

--- a/src/components/UI.tsx
+++ b/src/components/UI.tsx
@@ -558,8 +558,12 @@ const UI: React.FC<UIProps> = ({
             left: isMobile ? '1rem' : '1.25rem',
             bottom: isMobile ? '1rem' : '1.25rem',
             zIndex: tokens.zIndex.ui,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
             width: '2.5rem',
             height: '2.5rem',
+            padding: 0,
             border: '1px solid rgba(255, 255, 255, 0.18)',
             borderRadius: '999px',
             background: 'rgba(9, 18, 28, 0.52)',
@@ -567,12 +571,24 @@ const UI: React.FC<UIProps> = ({
             backdropFilter: 'blur(14px)',
             WebkitBackdropFilter: 'blur(14px)',
             boxShadow: '0 10px 24px rgba(0, 0, 0, 0.24)',
-            fontFamily: tokens.typography.fontFamily.serif,
-            fontSize: '16px',
             cursor: 'pointer',
           }}
         >
-          ?
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            width="16"
+            height="16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="12" cy="12" r="9" opacity="0.35" />
+            <path d="M9.7 9.2a2.65 2.65 0 0 1 5.12.92c0 1.88-1.9 2.55-2.6 3.48-.25.33-.34.62-.34 1.4" />
+            <path d="M12 17.25h.01" />
+          </svg>
         </button>
       )}
 

--- a/src/components/UI.tsx
+++ b/src/components/UI.tsx
@@ -97,6 +97,10 @@ const UI: React.FC<UIProps> = ({
       ? "環境音はここで切り替え"
       : "環境音はこのパネルで切り替え";
 
+  const showFloatingUiHint = showUiHint && !isSeasonPanelOpen;
+  const showInlineAmbientHint =
+    showUiHint && isSeasonPanelOpen && progress.hasOpenedPanel && !progress.hasToggledAmbient;
+
   const getButtonStyle = (isActive: boolean) => ({
     fontFamily: tokens.typography.fontFamily.serif,
     fontSize: '16px',
@@ -262,6 +266,9 @@ const UI: React.FC<UIProps> = ({
               style={{
                 display: 'flex',
                 justifyContent: isMobile ? 'center' : 'flex-end',
+                flexDirection: 'column',
+                alignItems: isMobile ? 'stretch' : 'flex-end',
+                gap: tokens.spacing.xs,
               }}
             >
               <button
@@ -283,6 +290,29 @@ const UI: React.FC<UIProps> = ({
                     : "環境音 ON"
                   : "環境音 非対応"}
               </button>
+
+              {showInlineAmbientHint && (
+                <div
+                  style={{
+                    alignSelf: isMobile ? 'stretch' : 'flex-end',
+                    maxWidth: isMobile ? '100%' : '220px',
+                    padding: isMobile ? '8px 10px' : '8px 12px',
+                    border: '1px solid rgba(255, 255, 255, 0.16)',
+                    borderRadius: '12px',
+                    background: 'rgba(9, 18, 28, 0.42)',
+                    color: 'rgba(255, 255, 255, 0.86)',
+                    boxShadow: '0 8px 20px rgba(0, 0, 0, 0.2)',
+                    backdropFilter: 'blur(12px)',
+                    WebkitBackdropFilter: 'blur(12px)',
+                    fontFamily: tokens.typography.fontFamily.serif,
+                    fontSize: isMobile ? '11px' : '12px',
+                    lineHeight: 1.5,
+                    textAlign: isMobile ? 'center' : 'left',
+                  }}
+                >
+                  {uiHintText}
+                </div>
+              )}
             </div>
           </div>
 
@@ -397,11 +427,11 @@ const UI: React.FC<UIProps> = ({
         </button>
       )}
 
-      {showUiHint && (
+      {showFloatingUiHint && (
         <div
           style={{
             position: 'fixed',
-            top: isMobile ? '5.5rem' : '6rem',
+            top: isMobile ? '5.75rem' : '6.25rem',
             right: isMobile ? tokens.positioning.mobile.right : tokens.positioning.pc.right,
             zIndex: tokens.zIndex.modal,
             maxWidth: isMobile ? '180px' : '240px',

--- a/src/components/UI.tsx
+++ b/src/components/UI.tsx
@@ -4,16 +4,44 @@ import SimulationClock from "./SimulationClock";
 import { tokens } from "@/styles/tokens";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useAmbientSound } from "@/hooks/useAmbientSound";
+import type { HintProgress } from "@/hooks/useUxHints";
+
+interface UIProps {
+  showHints?: boolean;
+  showUiHint?: boolean;
+  showWaterHint?: boolean;
+  hintProgress?: HintProgress;
+  onDismissHints?: () => void;
+  onReopenHints?: () => void;
+  onPanelOpened?: () => void;
+  onAmbientToggle?: () => void;
+}
 
 /**
  * メインUIコンポーネント
  * 時計表示と季節選択パネルを提供
  */
-const UI: React.FC = () => {
+const UI: React.FC<UIProps> = ({
+  showHints = false,
+  showUiHint = false,
+  showWaterHint = false,
+  hintProgress,
+  onDismissHints,
+  onReopenHints,
+  onPanelOpened,
+  onAmbientToggle,
+}) => {
   const { season, setSeason } = useSeason();
   const isMobile = useIsMobile();
   const [isSeasonPanelOpen, setIsSeasonPanelOpen] = useState(false);
   const ambientControls = useAmbientSound();
+
+  const progress = hintProgress ?? {
+    hasOpenedPanel: false,
+    hasToggledAmbient: false,
+    hasWaterRippled: false,
+    hasBottleOpened: false,
+  };
 
   const handleSeasonChange = (
     newSeason: "spring" | "summer" | "autumn" | "winter"
@@ -31,6 +59,43 @@ const UI: React.FC = () => {
     autumn: "秋",
     winter: "冬",
   };
+
+  const handleOpenPanel = () => {
+    setIsSeasonPanelOpen(true);
+    onPanelOpened?.();
+  };
+
+  const handleAmbientToggle = () => {
+    ambientControls.toggleMute();
+    onAmbientToggle?.();
+  };
+
+  const guideItems = [
+    {
+      done: progress.hasOpenedPanel,
+      label: "右上から季節をひらく",
+    },
+    {
+      done: progress.hasToggledAmbient,
+      label: isMobile ? "環境音をタップで切り替える" : "環境音をクリックして切り替える",
+    },
+    {
+      done: progress.hasBottleOpened,
+      label: isMobile ? "漂流瓶をタップして便りを読む" : "漂流瓶をクリックして便りを読む",
+    },
+    {
+      done: progress.hasWaterRippled,
+      label: isMobile ? "水面をタップして波紋を見る" : "水面をクリックして波紋を見る",
+    },
+  ];
+
+  const uiHintText = !progress.hasOpenedPanel
+    ? isMobile
+      ? "ここから季節と音をひらく"
+      : "ここから季節と環境音をひらく"
+    : isMobile
+      ? "環境音はここで切り替え"
+      : "環境音はこのパネルで切り替え";
 
   const getButtonStyle = (isActive: boolean) => ({
     fontFamily: tokens.typography.fontFamily.serif,
@@ -200,7 +265,7 @@ const UI: React.FC = () => {
               }}
             >
               <button
-                onClick={ambientControls.toggleMute}
+                onClick={handleAmbientToggle}
                 disabled={!ambientControls.isSupported}
                 aria-pressed={ambientControls.isMuted}
                 style={{
@@ -281,7 +346,7 @@ const UI: React.FC = () => {
       {/* 開くボタン */}
       {!isSeasonPanelOpen && (
         <button
-          onClick={() => setIsSeasonPanelOpen(true)}
+          onClick={handleOpenPanel}
           aria-label="UIパネルを開く"
           style={{
             position: 'fixed',
@@ -330,6 +395,182 @@ const UI: React.FC = () => {
         >
           {seasonIcons[season]}
         </button>
+      )}
+
+      {showUiHint && (
+        <div
+          style={{
+            position: 'fixed',
+            top: isMobile ? '5.5rem' : '6rem',
+            right: isMobile ? tokens.positioning.mobile.right : tokens.positioning.pc.right,
+            zIndex: tokens.zIndex.modal,
+            maxWidth: isMobile ? '180px' : '240px',
+            padding: isMobile ? '8px 12px' : '10px 14px',
+            border: '1px solid rgba(255, 255, 255, 0.18)',
+            borderRadius: '14px',
+            background: 'rgba(9, 18, 28, 0.6)',
+            color: 'rgba(255, 255, 255, 0.92)',
+            boxShadow: '0 14px 32px rgba(0, 0, 0, 0.25)',
+            backdropFilter: 'blur(14px)',
+            WebkitBackdropFilter: 'blur(14px)',
+            fontFamily: tokens.typography.fontFamily.serif,
+            fontSize: isMobile ? '12px' : '13px',
+            lineHeight: 1.6,
+            pointerEvents: 'none',
+          }}
+        >
+          {uiHintText}
+        </div>
+      )}
+
+      {showHints && (
+        <div
+          style={{
+            position: 'fixed',
+            left: isMobile ? '1rem' : '1.25rem',
+            bottom: isMobile ? '1rem' : '1.25rem',
+            zIndex: tokens.zIndex.modal,
+            width: isMobile ? 'min(88vw, 320px)' : '320px',
+            padding: isMobile ? '14px' : '16px',
+            border: '1px solid rgba(255, 255, 255, 0.16)',
+            borderRadius: '18px',
+            background: 'linear-gradient(160deg, rgba(9, 18, 28, 0.72), rgba(18, 28, 42, 0.46))',
+            color: 'rgba(255, 255, 255, 0.92)',
+            boxShadow: '0 16px 36px rgba(0, 0, 0, 0.3)',
+            backdropFilter: 'blur(18px)',
+            WebkitBackdropFilter: 'blur(18px)',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'flex-start',
+              justifyContent: 'space-between',
+              gap: tokens.spacing.md,
+              marginBottom: tokens.spacing.sm,
+            }}
+          >
+            <div>
+              <div
+                style={{
+                  marginBottom: '4px',
+                  fontFamily: tokens.typography.fontFamily.serif,
+                  fontSize: isMobile ? '14px' : '15px',
+                  fontWeight: 500,
+                  letterSpacing: '0.08em',
+                }}
+              >
+                はじめての歩き方
+              </div>
+              <div
+                style={{
+                  fontSize: isMobile ? '12px' : '13px',
+                  lineHeight: 1.6,
+                  color: 'rgba(255, 255, 255, 0.72)',
+                }}
+              >
+                気になる場所を少しずつ触ると、この水辺の表情がひらきます。
+              </div>
+            </div>
+
+            <button
+              onClick={onDismissHints}
+              aria-label="操作ヒントを閉じる"
+              style={{
+                width: '2rem',
+                height: '2rem',
+                padding: 0,
+                border: '1px solid rgba(255, 255, 255, 0.18)',
+                borderRadius: '999px',
+                background: 'rgba(255, 255, 255, 0.06)',
+                color: 'rgba(255, 255, 255, 0.86)',
+                cursor: 'pointer',
+              }}
+            >
+              ✕
+            </button>
+          </div>
+
+          <div
+            style={{
+              display: 'grid',
+              gap: '10px',
+            }}
+          >
+            {guideItems.map((item) => (
+              <div
+                key={item.label}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: tokens.spacing.sm,
+                  fontSize: isMobile ? '12px' : '13px',
+                  lineHeight: 1.5,
+                  color: item.done ? 'rgba(255, 255, 255, 0.64)' : 'rgba(255, 255, 255, 0.92)',
+                }}
+              >
+                <span aria-hidden="true" style={{ fontSize: '15px' }}>
+                  {item.done ? '✓' : '○'}
+                </span>
+                <span>{item.label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {!showHints && onReopenHints && (
+        <button
+          onClick={onReopenHints}
+          aria-label="操作ヒントを再表示"
+          style={{
+            position: 'fixed',
+            left: isMobile ? '1rem' : '1.25rem',
+            bottom: isMobile ? '1rem' : '1.25rem',
+            zIndex: tokens.zIndex.ui,
+            width: '2.5rem',
+            height: '2.5rem',
+            border: '1px solid rgba(255, 255, 255, 0.18)',
+            borderRadius: '999px',
+            background: 'rgba(9, 18, 28, 0.52)',
+            color: 'rgba(255, 255, 255, 0.9)',
+            backdropFilter: 'blur(14px)',
+            WebkitBackdropFilter: 'blur(14px)',
+            boxShadow: '0 10px 24px rgba(0, 0, 0, 0.24)',
+            fontFamily: tokens.typography.fontFamily.serif,
+            fontSize: '16px',
+            cursor: 'pointer',
+          }}
+        >
+          ?
+        </button>
+      )}
+
+      {showWaterHint && (
+        <div
+          style={{
+            position: 'fixed',
+            left: '50%',
+            bottom: isMobile ? '1rem' : '1.25rem',
+            transform: 'translateX(-50%)',
+            zIndex: tokens.zIndex.ui,
+            padding: isMobile ? '8px 12px' : '10px 16px',
+            border: '1px solid rgba(255, 255, 255, 0.18)',
+            borderRadius: '999px',
+            background: 'rgba(9, 18, 28, 0.52)',
+            color: 'rgba(255, 255, 255, 0.92)',
+            boxShadow: '0 10px 24px rgba(0, 0, 0, 0.24)',
+            backdropFilter: 'blur(14px)',
+            WebkitBackdropFilter: 'blur(14px)',
+            fontFamily: tokens.typography.fontFamily.serif,
+            fontSize: isMobile ? '12px' : '13px',
+            letterSpacing: '0.04em',
+            pointerEvents: 'none',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {isMobile ? '水面をタップすると波紋がひろがります' : '水面をクリックすると波紋がひろがります'}
+        </div>
       )}
     </>
   );

--- a/src/components/WaterSurface.tsx
+++ b/src/components/WaterSurface.tsx
@@ -37,7 +37,11 @@ interface RipplePoint {
  * 水面コンポーネント
  * 波紋アニメーションと光の反射を持つ透明な水面を表示
  */
-const WaterSurface: React.FC = () => {
+interface WaterSurfaceProps {
+  onInteract?: () => void;
+}
+
+const WaterSurface: React.FC<WaterSurfaceProps> = ({ onInteract }) => {
   const meshRef = useRef<THREE.Mesh>(null!);
   const geometryRef = useRef<THREE.PlaneGeometry>(null!);
   const ripplesRef = useRef<RipplePoint[]>([]);
@@ -73,7 +77,8 @@ const WaterSurface: React.FC = () => {
     } satisfies RipplePoint;
 
     ripplesRef.current = [...ripplesRef.current.slice(-(WATER_RIPPLE_MAX_COUNT - 1)), ripplePoint];
-  }, []);
+    onInteract?.();
+  }, [onInteract]);
 
   useThrottledFrame((state) => {
     if (!meshRef.current || !geometryRef.current) return;

--- a/src/hooks/useUxHints.ts
+++ b/src/hooks/useUxHints.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+const HINTS_STORAGE_KEY = "mizube-ux-hints-dismissed";
+
+interface HintProgress {
+  hasOpenedPanel: boolean;
+  hasToggledAmbient: boolean;
+  hasWaterRippled: boolean;
+  hasBottleOpened: boolean;
+}
+
+const DEFAULT_PROGRESS: HintProgress = {
+  hasOpenedPanel: false,
+  hasToggledAmbient: false,
+  hasWaterRippled: false,
+  hasBottleOpened: false,
+};
+
+const readDismissedState = () => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return window.localStorage.getItem(HINTS_STORAGE_KEY) === "true";
+};
+
+const writeDismissedState = () => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(HINTS_STORAGE_KEY, "true");
+};
+
+export const useUxHints = () => {
+  const [hasDismissedHints, setHasDismissedHints] = useState(readDismissedState);
+  const [showHints, setShowHints] = useState(() => !readDismissedState());
+  const [progress, setProgress] = useState<HintProgress>(DEFAULT_PROGRESS);
+
+  const markProgress = useCallback((key: keyof HintProgress) => {
+    setProgress((prev) => {
+      if (prev[key]) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        [key]: true,
+      };
+    });
+  }, []);
+
+  const dismissHints = useCallback(() => {
+    setShowHints(false);
+
+    if (!hasDismissedHints) {
+      setHasDismissedHints(true);
+      writeDismissedState();
+    }
+  }, [hasDismissedHints]);
+
+  const reopenHints = useCallback(() => {
+    setShowHints(true);
+  }, []);
+
+  const isFullyExplored = useMemo(
+    () => Object.values(progress).every(Boolean),
+    [progress]
+  );
+
+  useEffect(() => {
+    if (!isFullyExplored || hasDismissedHints) {
+      return;
+    }
+
+    setHasDismissedHints(true);
+    setShowHints(false);
+    writeDismissedState();
+  }, [hasDismissedHints, isFullyExplored]);
+
+  return {
+    progress,
+    showHints,
+    hasDismissedHints,
+    shouldShowUiHint:
+      showHints && (!progress.hasOpenedPanel || !progress.hasToggledAmbient),
+    shouldShowBottleHint: showHints && !progress.hasBottleOpened,
+    shouldShowWaterHint: showHints && !progress.hasWaterRippled,
+    dismissHints,
+    reopenHints,
+    markPanelOpened: () => markProgress("hasOpenedPanel"),
+    markAmbientToggled: () => markProgress("hasToggledAmbient"),
+    markWaterRippled: () => markProgress("hasWaterRippled"),
+    markBottleOpened: () => markProgress("hasBottleOpened"),
+  };
+};
+
+export type { HintProgress };


### PR DESCRIPTION
## 概要
- 初回ユーザー向けの操作ヒント導線を追加
- `UI` / 漂流瓶 / 水面の発見性を上げるオンボーディングを実装
- 一度閉じたヒントは `localStorage` で通常再表示しないように調整

## 変更内容
- `useUxHints` を追加してヒント表示状態と進捗管理を集約
- 右上 UI の導線ヒントを追加
- 左下の「はじめての歩き方」カードと再表示 `?` ボタンを追加
- 漂流瓶の近くにクリック / タップ誘導ラベルを追加
- 水面クリック時に波紋ヒントの進捗が進むように連携
- ローディング中はヒント UI を出さないように調整

## 動作確認
- `volta run npm run build`
- `volta run npm run lint`

Closes #50
