### PR TITLE
fix: 雨エフェクトの見え方を調整

### DIFF
--- a/src/components/RainEffect.tsx
+++ b/src/components/RainEffect.tsx
@@ -8,13 +8,29 @@ import {
   RAIN_SPAWN_AREA,
   RAIN_COLOR,
   RAIN_OPACITY,
+  RAIN_RESET_Y,
+  RAIN_DROP_TILT,
 } from '../constants/rainEffect';
 
 interface RainDrop {
   position: [number, number, number];
   velocity: [number, number];
-  phase: number;
 }
+
+const spawnRainDrop = (): RainDrop => ({
+  position: [
+    Math.random() * (RAIN_SPAWN_AREA.X_MAX - RAIN_SPAWN_AREA.X_MIN) +
+      RAIN_SPAWN_AREA.X_MIN,
+    Math.random() * (RAIN_SPAWN_AREA.Y_MAX - RAIN_SPAWN_AREA.Y_MIN) +
+      RAIN_SPAWN_AREA.Y_MIN,
+    Math.random() * (RAIN_SPAWN_AREA.Z_MAX - RAIN_SPAWN_AREA.Z_MIN) +
+      RAIN_SPAWN_AREA.Z_MIN,
+  ] as [number, number, number],
+  velocity: [
+    RAIN_DROP_SPEED.X_BASE + (Math.random() - 0.5) * RAIN_DROP_SPEED.X_VARIATION,
+    -(RAIN_DROP_SPEED.Y_BASE + Math.random() * RAIN_DROP_SPEED.Y_VARIATION),
+  ] as [number, number],
+});
 
 const RainEffect: React.FC = () => {
   const meshRef = useRef<THREE.InstancedMesh>(null);
@@ -22,45 +38,28 @@ const RainEffect: React.FC = () => {
 
   // 雨粒の初期データを生成（一度だけ）
   const rainDrops = useMemo<RainDrop[]>(() => {
-    return Array.from({ length: RAIN_DROP_COUNT }, () => ({
-      position: [
-        Math.random() * (RAIN_SPAWN_AREA.X_MAX - RAIN_SPAWN_AREA.X_MIN) +
-          RAIN_SPAWN_AREA.X_MIN,
-        Math.random() * 10 + RAIN_SPAWN_AREA.Y,
-        Math.random() * (RAIN_SPAWN_AREA.Z_MAX - RAIN_SPAWN_AREA.Z_MIN) +
-          RAIN_SPAWN_AREA.Z_MIN,
-      ] as [number, number, number],
-      velocity: [
-        (Math.random() - 0.5) * RAIN_DROP_SPEED.X_VARIATION,
-        RAIN_DROP_SPEED.Y,
-      ] as [number, number],
-      phase: Math.random() * Math.PI * 2,
-    }));
+    return Array.from({ length: RAIN_DROP_COUNT }, spawnRainDrop);
   }, []);
 
   // アニメーション
-  useFrame(() => {
+  useFrame((_, delta) => {
     if (!meshRef.current) return;
 
     rainDrops.forEach((drop, i) => {
       // 落下処理
-      drop.position[1] += drop.velocity[1];
-      drop.position[0] += drop.velocity[0];
+      drop.position[1] += drop.velocity[1] * delta;
+      drop.position[0] += drop.velocity[0] * delta;
 
       // 地面に到達したらリセット
-      if (drop.position[1] < 0) {
-        drop.position[1] = RAIN_SPAWN_AREA.Y;
-        drop.position[0] =
-          Math.random() * (RAIN_SPAWN_AREA.X_MAX - RAIN_SPAWN_AREA.X_MIN) +
-          RAIN_SPAWN_AREA.X_MIN;
-        drop.position[2] =
-          Math.random() * (RAIN_SPAWN_AREA.Z_MAX - RAIN_SPAWN_AREA.Z_MIN) +
-          RAIN_SPAWN_AREA.Z_MIN;
+      if (drop.position[1] < RAIN_RESET_Y) {
+        const nextDrop = spawnRainDrop();
+        drop.position = nextDrop.position;
+        drop.velocity = nextDrop.velocity;
       }
 
       // 行列を更新
       dummy.position.set(drop.position[0], drop.position[1], drop.position[2]);
-      dummy.rotation.z = drop.phase;
+      dummy.rotation.z = RAIN_DROP_TILT;
       dummy.updateMatrix();
       if (meshRef.current) {
         meshRef.current.setMatrixAt(i, dummy.matrix);

--- a/src/constants/rainEffect.ts
+++ b/src/constants/rainEffect.ts
@@ -1,29 +1,35 @@
 // 雨エフェクトの定数設定
 
 // 雨粒の数
-export const RAIN_DROP_COUNT = 500;
+export const RAIN_DROP_COUNT = 320;
 
 // 雨粒のサイズ
 export const RAIN_DROP_SIZE = {
-  WIDTH: 0.02,
-  HEIGHT: 0.3,
+  WIDTH: 0.006,
+  HEIGHT: 0.16,
 } as const;
 
 // 雨粒の速度
 export const RAIN_DROP_SPEED = {
-  Y: -0.5, // 落下速度
-  X_VARIATION: 0.05, // 風による横ブレ
+  Y_BASE: 6.5, // 1秒あたりの落下速度
+  Y_VARIATION: 2.5,
+  X_BASE: -1.2, // 風による横流れ
+  X_VARIATION: 0.7,
 } as const;
 
 // 雨粒の生成範囲
 export const RAIN_SPAWN_AREA = {
   X_MIN: -15,
   X_MAX: 15,
-  Y: 20, // 高い位置から生成
+  Y_MIN: 12,
+  Y_MAX: 22,
   Z_MIN: -15,
   Z_MAX: 15,
 } as const;
 
+export const RAIN_RESET_Y = -1;
+export const RAIN_DROP_TILT = -0.18;
+
 // 雨粒の色
-export const RAIN_COLOR = '#b0c4de'; // 薄い青
-export const RAIN_OPACITY = 0.6;
+export const RAIN_COLOR = '#d9e6ff'; // 薄い青
+export const RAIN_OPACITY = 0.32;

--- a/temp/025_issue-64-sugoi-falling/plan.md
+++ b/temp/025_issue-64-sugoi-falling/plan.md
@@ -1,0 +1,12 @@
+# Implementation Plan: Issue #64
+
+Issue: https://github.com/andsaki/biotope/issues/64
+Title: なんかすごいの降ってる
+
+## Plan
+
+1. Inspect the existing rain and seasonal particle systems.
+2. Add a dramatic, high-density falling rain layer suitable for June/rainy-season scenes.
+3. Keep the change scoped so existing seasonal effects and unrelated local edits are preserved.
+4. Run typecheck, lint, build, and browser smoke verification.
+5. Commit only issue #64 files, push, open PR, and comment on the issue.

--- a/temp/025_issue-64-sugoi-falling/prompt.md
+++ b/temp/025_issue-64-sugoi-falling/prompt.md
@@ -1,0 +1,29 @@
+# Implementation Session: Issue #64
+
+## Issue
+
+- URL: https://github.com/andsaki/biotope/issues/64
+- Title: なんかすごいの降ってる
+- Body: image attachment only.
+
+## Notes
+
+- Existing worktree had unrelated uncommitted changes in `index.html`, `vite.config.ts`, and public icon/manifest assets before this work started.
+- Those files should be preserved and excluded from the issue #64 commit unless required.
+- Issue attachment saved to `temp/025_issue-64-sugoi-falling/issue-attachment.png`.
+
+## Implementation
+
+- Reduced June rain particle count, dimensions, and opacity.
+- Changed rain movement to delta-time based speeds so the visible fall rate is stable across frame rates.
+- Removed random full-circle drop rotation and replaced it with a consistent wind tilt, avoiding the oversized debris-like rods shown in the issue screenshot.
+
+## Verification
+
+- `npx tsc --noEmit`: passed.
+- `npm run lint`: passed.
+- `npm run build`: passed.
+- Chrome MCP desktop screenshot: `temp/025_issue-64-sugoi-falling/desktop.png`.
+- Chrome MCP mobile screenshot: `temp/025_issue-64-sugoi-falling/mobile.png`.
+- Chrome console check showed one pre-existing React warning/error: `Cannot update a component (LoadingTracker) while rendering a different component (Frog)`.
+- Dev server ran on `http://127.0.0.1:4173/` and was stopped; port 4173 is clear.


### PR DESCRIPTION
## Summary
- Issue #64 のスクリーンショットで目立っていた巨大な雨粒表示を抑制
- 雨粒を小さく薄くし、ランダムな全方向回転を一定の風向きチルトに変更
- フレームレート依存の移動量を delta time ベースに変更

## Test plan
- [x] npx tsc --noEmit
- [x] npm run lint
- [x] npm run build
- [x] Chrome MCP desktop/mobile screenshot verification

Closes #64