### PR TITLE
feature: 瓶の便りに観察ログと履歴を追加 (#66)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -243,6 +243,7 @@ const AppContent = () => {
               position={[-3, 8.2, 2]}
               onMessageRead={uxHints.markBottleOpened}
               showHint={!isLoading && uxHints.shouldShowBottleHint}
+              windDirection={windDirection}
             />
           </Suspense>
           <Suspense fallback={null}>

--- a/src/components/DriftingBottle/MessageCard.tsx
+++ b/src/components/DriftingBottle/MessageCard.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 import { Html } from "@react-three/drei";
+import { formatJournalDate, type BottleJournalEntry } from "@/utils/bottleJournal";
 
 /** メッセージカードのプロパティ */
 interface MessageCardProps {
@@ -7,6 +8,12 @@ interface MessageCardProps {
   message: string;
   /** 送り主 */
   sender: string;
+  /** 今日の観察ログ */
+  lifeLog: string;
+  /** 表示中の便りの日付 */
+  currentDate: string;
+  /** 保存済みの便り履歴 */
+  journalEntries: BottleJournalEntry[];
   /** 閉じるボタンのクリックハンドラ */
   onClose: (e: React.MouseEvent) => void;
 }
@@ -27,6 +34,10 @@ const CARD_STYLES = {
     overflow: "hidden" as const,
     display: "flex",
     flexDirection: "column" as const,
+  },
+  content: {
+    overflowY: "auto" as const,
+    paddingRight: "4px",
   },
   closeButton: {
     position: "absolute" as const,
@@ -66,13 +77,73 @@ const CARD_STYLES = {
     color: "#8b7355",
     fontStyle: "italic" as const,
   },
+  section: {
+    marginTop: "18px",
+    paddingTop: "14px",
+    borderTop: "1px solid rgba(139, 115, 85, 0.28)",
+  },
+  sectionTitle: {
+    margin: "0 0 8px 0",
+    color: "#5d4e37",
+    fontSize: "13px",
+    letterSpacing: "0.08em",
+  },
+  lifeLog: {
+    margin: "0",
+    color: "#5f5548",
+    fontSize: "12px",
+    lineHeight: "1.7",
+  },
+  historyList: {
+    display: "flex",
+    flexDirection: "column" as const,
+    gap: "10px",
+  },
+  historyItem: {
+    padding: "9px 10px",
+    borderRadius: "6px",
+    background: "rgba(255, 248, 235, 0.62)",
+    border: "1px solid rgba(212, 165, 116, 0.34)",
+  },
+  historyDate: {
+    margin: "0 0 4px 0",
+    color: "#8b7355",
+    fontSize: "11px",
+  },
+  historyText: {
+    margin: "0",
+    color: "#4f4a42",
+    fontSize: "12px",
+    lineHeight: "1.6",
+    display: "-webkit-box",
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: "vertical" as const,
+    overflow: "hidden",
+  },
+  emptyHistory: {
+    margin: "0",
+    color: "#8b7355",
+    fontSize: "12px",
+    lineHeight: "1.6",
+  },
 };
 
 /**
  * 瓶の中のメッセージを表示するカード
  * @param props - コンポーネントのプロパティ
  */
-export const MessageCard = memo(({ message, sender, onClose }: MessageCardProps) => {
+export const MessageCard = memo(({
+  message,
+  sender,
+  lifeLog,
+  currentDate,
+  journalEntries,
+  onClose,
+}: MessageCardProps) => {
+  const previousEntries = journalEntries.filter(
+    (entry) => entry.date !== currentDate
+  );
+
   return (
     <Html center distanceFactor={10} style={{ pointerEvents: "all" }}>
       <div style={CARD_STYLES.container} onClick={(e) => e.stopPropagation()}>
@@ -80,9 +151,30 @@ export const MessageCard = memo(({ message, sender, onClose }: MessageCardProps)
           ×
         </button>
         <h3 style={CARD_STYLES.title}>海からの便り</h3>
-        <div>
+        <div style={CARD_STYLES.content}>
           <p style={CARD_STYLES.message}>{message}</p>
           <div style={CARD_STYLES.sender}>— {sender}</div>
+          <section style={CARD_STYLES.section}>
+            <h4 style={CARD_STYLES.sectionTitle}>今日の観察</h4>
+            <p style={CARD_STYLES.lifeLog}>{lifeLog}</p>
+          </section>
+          <section style={CARD_STYLES.section}>
+            <h4 style={CARD_STYLES.sectionTitle}>これまでの便り</h4>
+            {previousEntries.length > 0 ? (
+              <div style={CARD_STYLES.historyList}>
+                {previousEntries.slice(0, 5).map((entry) => (
+                  <article key={entry.date} style={CARD_STYLES.historyItem}>
+                    <p style={CARD_STYLES.historyDate}>{formatJournalDate(entry.date)}</p>
+                    <p style={CARD_STYLES.historyText}>{entry.message}</p>
+                  </article>
+                ))}
+              </div>
+            ) : (
+              <p style={CARD_STYLES.emptyHistory}>
+                まだ過去の便りはありません。次に瓶を開くと、ここに記録が残ります。
+              </p>
+            )}
+          </section>
         </div>
       </div>
     </Html>

--- a/src/components/DriftingBottle/index.tsx
+++ b/src/components/DriftingBottle/index.tsx
@@ -1,8 +1,18 @@
-import { useState, useEffect } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { Html } from "@react-three/drei";
 import { fetchDailyMessage } from "../../utils/dailyMessage";
 import { useBottleAnimation } from "../../hooks/useBottleAnimation";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { useClockTime, useSeason } from "@/contexts";
+import { getTimeOfDay } from "@/utils/time";
+import {
+  createDailyLifeLog,
+  getLocalDateKey,
+  loadBottleJournal,
+  saveBottleJournalEntry,
+  type BottleJournalEntry,
+  type WindDirection,
+} from "@/utils/bottleJournal";
 import { BottleModel } from "./BottleModel";
 import { MessageCard } from "./MessageCard";
 
@@ -14,6 +24,8 @@ interface DriftingBottleProps {
   onMessageRead?: () => void;
   /** 初回導線ヒントの表示 */
   showHint?: boolean;
+  /** 現在の風向き */
+  windDirection?: WindDirection;
 }
 
 /**
@@ -25,15 +37,33 @@ export const DriftingBottle = ({
   position,
   onMessageRead,
   showHint = false,
+  windDirection = "East",
 }: DriftingBottleProps) => {
+  const { season } = useSeason();
+  const realTime = useClockTime();
   const [showMessage, setShowMessage] = useState(false);
   const [hovered, setHovered] = useState(false);
   const [currentMessage, setCurrentMessage] = useState("");
   const [currentSender, setCurrentSender] = useState("");
+  const [displayedLifeLog, setDisplayedLifeLog] = useState("");
   const [dailyMessageFetched, setDailyMessageFetched] = useState(false);
+  const [journalEntries, setJournalEntries] = useState<BottleJournalEntry[]>(() =>
+    loadBottleJournal()
+  );
   const isMobile = useIsMobile();
 
   const bottleRef = useBottleAnimation(position);
+  const today = useMemo(() => getLocalDateKey(), []);
+  const lifeLog = useMemo(
+    () =>
+      createDailyLifeLog({
+        date: today,
+        season,
+        timeOfDay: getTimeOfDay(realTime.hours),
+        windDirection,
+      }),
+    [realTime.hours, season, today, windDirection]
+  );
 
   // 1日1回、Gemini経由でメッセージを取得
   useEffect(() => {
@@ -57,9 +87,25 @@ export const DriftingBottle = ({
 
   const handleClick = () => {
     // 1日中同じGemini生成メッセージを表示
+    setDisplayedLifeLog(lifeLog);
     setShowMessage(true);
     onMessageRead?.();
   };
+
+  useEffect(() => {
+    if (!showMessage || !currentMessage || !currentSender || !displayedLifeLog) {
+      return;
+    }
+
+    const nextJournal = saveBottleJournalEntry({
+      date: today,
+      message: currentMessage,
+      sender: currentSender,
+      lifeLog: displayedLifeLog,
+      readAt: new Date().toISOString(),
+    });
+    setJournalEntries(nextJournal);
+  }, [currentMessage, currentSender, displayedLifeLog, showMessage, today]);
 
   const handleCloseMessage = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -101,6 +147,9 @@ export const DriftingBottle = ({
         <MessageCard
           message={currentMessage}
           sender={currentSender}
+          lifeLog={displayedLifeLog || lifeLog}
+          currentDate={today}
+          journalEntries={journalEntries}
           onClose={handleCloseMessage}
         />
       )}

--- a/src/hooks/useWindDirection.ts
+++ b/src/hooks/useWindDirection.ts
@@ -1,8 +1,6 @@
 import { useState, useEffect } from "react";
 import { WIND_CHANGE_INTERVAL } from "../constants/core";
-
-/** 風向きの種類 */
-type WindDirection = "North" | "East" | "South" | "West";
+import type { WindDirection } from "@/utils/bottleJournal";
 
 /**
  * 風向きを定期的に変更するカスタムフック

--- a/src/utils/bottleJournal.ts
+++ b/src/utils/bottleJournal.ts
@@ -1,0 +1,168 @@
+import type { Season } from "@/contexts/SeasonContext/context";
+import type { TimeOfDay } from "./time";
+
+export type WindDirection = "North" | "East" | "South" | "West";
+
+export interface BottleJournalEntry {
+  date: string;
+  message: string;
+  sender: string;
+  lifeLog: string;
+  readAt: string;
+}
+
+interface LifeLogInput {
+  date: string;
+  season: Season;
+  timeOfDay: TimeOfDay;
+  windDirection: WindDirection;
+}
+
+const JOURNAL_STORAGE_KEY = "mizube_bottle_journal";
+const MAX_JOURNAL_ENTRIES = 14;
+
+const seasonLabels: Record<Season, string> = {
+  spring: "春",
+  summer: "夏",
+  autumn: "秋",
+  winter: "冬",
+};
+
+const timeLabels: Record<TimeOfDay, string> = {
+  morning: "朝",
+  afternoon: "昼",
+  evening: "夕方",
+  night: "夜",
+};
+
+const windLabels: Record<WindDirection, string> = {
+  North: "北",
+  East: "東",
+  South: "南",
+  West: "西",
+};
+
+const seasonNotes: Record<Season, string[]> = {
+  spring: [
+    "水面に花びらが一枚、輪を描いて流れた",
+    "浅瀬の色がやわらかく、岸辺が少し明るく見えた",
+    "細い草の先に、春の光が長く残っていた",
+  ],
+  summer: [
+    "蓮の葉が波に合わせて、ゆっくり向きを変えた",
+    "水辺の空気が揺れて、光の粒が濃く見えた",
+    "魚影が日差しを避けるように、少し深い方へ移った",
+  ],
+  autumn: [
+    "落ち葉が水面で止まり、また小さく動き出した",
+    "岸の影が澄んで、葉の色だけが静かに浮いた",
+    "水面に残った葉脈が、夕方まで薄く光っていた",
+  ],
+  winter: [
+    "水面の色が冷えて、魚の動きもゆっくりになった",
+    "白い粒が落ちるたび、池の音が少し遠くなった",
+    "岸辺の影が短く固まり、空気だけが澄んでいた",
+  ],
+};
+
+const timeNotes: Record<TimeOfDay, string[]> = {
+  morning: [
+    "浅瀬には早い時間の静けさが残っていた",
+    "光が低く入り、波紋の縁だけが見えた",
+  ],
+  afternoon: [
+    "水面は明るく、動くものの影が短く沈んだ",
+    "池の中央に光が集まり、岸辺は少し眠そうだった",
+  ],
+  evening: [
+    "夕方の色が水面に伸び、輪郭がゆっくり溶けた",
+    "沈む光に合わせて、漂うものの速度も落ちた",
+  ],
+  night: [
+    "暗い水面に、見えるものだけが小さく残った",
+    "夜の池は静かで、遠い反射だけが揺れていた",
+  ],
+};
+
+const createSeed = (value: string) => {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+};
+
+const pick = <T,>(items: T[], seed: number) => items[seed % items.length];
+
+export const getLocalDateKey = (date = new Date()) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+export const formatJournalDate = (dateKey: string) => {
+  const [, month, day] = dateKey.split("-");
+  return `${Number(month)}月${Number(day)}日`;
+};
+
+export const createDailyLifeLog = ({
+  date,
+  season,
+  timeOfDay,
+  windDirection,
+}: LifeLogInput) => {
+  const seed = createSeed(`${date}:${season}:${timeOfDay}:${windDirection}`);
+  const seasonalText = pick(seasonNotes[season], seed);
+  const timeText = pick(timeNotes[timeOfDay], seed >>> 3);
+  const windText = `${windLabels[windDirection]}からの風。`;
+
+  return `${formatJournalDate(date)}、${seasonLabels[season]}の${timeLabels[timeOfDay]}。${seasonalText}。${timeText}。${windText}`;
+};
+
+export const loadBottleJournal = (): BottleJournalEntry[] => {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const rawJournal = window.localStorage.getItem(JOURNAL_STORAGE_KEY);
+    if (!rawJournal) {
+      return [];
+    }
+
+    const parsed = JSON.parse(rawJournal);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter(
+      (entry): entry is BottleJournalEntry =>
+        typeof entry?.date === "string" &&
+        typeof entry?.message === "string" &&
+        typeof entry?.sender === "string" &&
+        typeof entry?.lifeLog === "string" &&
+        typeof entry?.readAt === "string"
+    );
+  } catch (error) {
+    console.error("Error loading bottle journal:", error);
+    return [];
+  }
+};
+
+export const saveBottleJournalEntry = (entry: BottleJournalEntry) => {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  const withoutSameDate = loadBottleJournal().filter(
+    (storedEntry) => storedEntry.date !== entry.date
+  );
+  const nextJournal = [entry, ...withoutSameDate]
+    .sort((a, b) => b.date.localeCompare(a.date))
+    .slice(0, MAX_JOURNAL_ENTRIES);
+
+  window.localStorage.setItem(JOURNAL_STORAGE_KEY, JSON.stringify(nextJournal));
+  return nextJournal;
+};


### PR DESCRIPTION
## 概要
- Issue #66 の実装です。
- 漂流瓶の便箋に、その日の季節・時間帯・風向きから作る短い観察ログを追加しました。
- 読んだ便りを localStorage に保存し、過去の便りを便箋内で見返せるようにしました。

## 変更内容
- `bottleJournal` ユーティリティを追加し、生態ログ生成、日付表示、履歴の読み書きを集約
- `DriftingBottle` で現在の季節・時刻・風向きから観察ログを生成し、瓶を開いたタイミングの内容を保存
- `MessageCard` に「今日の観察」と「これまでの便り」を追加
- 風向き型を共通化し、`App` から漂流瓶へ現在の風向きを渡すように変更

## テスト計画
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Chrome DevTools MCP 上で生態ログ生成と localStorage 保存を確認
- [x] 実ブラウザ操作で便箋内の「今日の観察」と「これまでの便り」の空状態表示を確認

Closes #66

🤖 Generated with [Codex CLI](https://openai.com/codex)