### PR TITLE
feature: 実天気を水辺の表現に反映

### DIFF
--- a/functions/api/weather.ts
+++ b/functions/api/weather.ts
@@ -1,0 +1,154 @@
+/**
+ * Cloudflare Functions - 現在の天気API
+ * Open-Meteoから東京の現在天気を取得する
+ */
+
+/// <reference types="@cloudflare/workers-types" />
+
+interface OpenMeteoCurrent {
+  time: string;
+  weather_code: number;
+  precipitation: number;
+  rain: number;
+  showers: number;
+  snowfall: number;
+  cloud_cover: number;
+  wind_direction_10m: number;
+}
+
+interface OpenMeteoResponse {
+  current: OpenMeteoCurrent;
+}
+
+type WeatherCondition = "clear" | "cloudy" | "rain";
+
+const TOKYO_STATION = {
+  name: "東京",
+  latitude: 35.6812,
+  longitude: 139.7671,
+} as const;
+
+const CACHE_TTL_SECONDS = 30 * 60;
+
+const WEATHER_LABELS: Record<WeatherCondition, string> = {
+  clear: "晴",
+  cloudy: "曇",
+  rain: "雨",
+};
+
+const WEATHER_DESCRIPTIONS: Record<WeatherCondition, string> = {
+  clear: "東京の空が明るい",
+  cloudy: "東京の光がやわらぐ",
+  rain: "東京に雨が降る",
+};
+
+const rainyWeatherCodes = new Set([
+  51, 53, 55, 56, 57, 61, 63, 65, 66, 67, 71, 73, 75, 77, 80, 81, 82, 85, 86,
+  95, 96, 99,
+]);
+
+const cloudyWeatherCodes = new Set([2, 3, 45, 48]);
+
+const getCondition = (current: OpenMeteoCurrent): WeatherCondition => {
+  const precipitation =
+    current.precipitation + current.rain + current.showers + current.snowfall;
+
+  if (precipitation > 0 || rainyWeatherCodes.has(current.weather_code)) {
+    return "rain";
+  }
+
+  if (current.cloud_cover >= 55 || cloudyWeatherCodes.has(current.weather_code)) {
+    return "cloudy";
+  }
+
+  return "clear";
+};
+
+export const onRequest = async (context: EventContext<unknown, string, Record<string, unknown>>) => {
+  const corsHeaders = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  };
+
+  if (context.request.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const apiUrl = new URL("https://api.open-meteo.com/v1/forecast");
+    apiUrl.searchParams.set("latitude", String(TOKYO_STATION.latitude));
+    apiUrl.searchParams.set("longitude", String(TOKYO_STATION.longitude));
+    apiUrl.searchParams.set(
+      "current",
+      [
+        "weather_code",
+        "precipitation",
+        "rain",
+        "showers",
+        "snowfall",
+        "cloud_cover",
+        "wind_direction_10m",
+      ].join(",")
+    );
+    apiUrl.searchParams.set("timezone", "Asia/Tokyo");
+    apiUrl.searchParams.set("forecast_days", "1");
+
+    const response = await fetch(apiUrl.toString(), {
+      headers: {
+        Accept: "application/json",
+      },
+      cf: {
+        cacheTtl: CACHE_TTL_SECONDS,
+        cacheEverything: true,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Open-Meteo API error: ${response.status}`);
+    }
+
+    const data: OpenMeteoResponse = await response.json();
+    const current = data.current;
+    const condition = getCondition(current);
+
+    return new Response(
+      JSON.stringify({
+        condition,
+        label: WEATHER_LABELS[condition],
+        description: WEATHER_DESCRIPTIONS[condition],
+        observedAt: current.time,
+        source: "open-meteo",
+        location: TOKYO_STATION.name,
+        weatherCode: current.weather_code,
+        cloudCover: current.cloud_cover,
+        precipitation:
+          current.precipitation + current.rain + current.showers + current.snowfall,
+        windDirection: current.wind_direction_10m,
+        cacheTtl: CACHE_TTL_SECONDS,
+      }),
+      {
+        headers: {
+          ...corsHeaders,
+          "Content-Type": "application/json",
+          "Cache-Control": `public, max-age=0, s-maxage=${CACHE_TTL_SECONDS}`,
+        },
+      }
+    );
+  } catch (error) {
+    console.error("Error fetching weather:", error);
+    return new Response(
+      JSON.stringify({
+        error: "Failed to fetch weather",
+      }),
+      {
+        status: 502,
+        headers: {
+          ...corsHeaders,
+          "Content-Type": "application/json",
+          "Cache-Control": "no-store",
+        },
+      }
+    );
+  }
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import "./App.css";
 import { SIMULATED_SECONDS_PER_REAL_SECOND } from "./constants/core";
 import { useIsMobile } from "./hooks/useIsMobile";
 import { useWindDirection } from "./hooks/useWindDirection";
+import { useWeather } from "./hooks/useWeather";
 import { useUxHints } from "./hooks/useUxHints";
 
 // const DEBUG_MODE = false; // デバッグヘルパーの表示切替 - 削除
@@ -91,6 +92,7 @@ type AppStyle = React.CSSProperties & { "--app-background-color"?: string };
 const AppContent = () => {
   const isDay = useDayPeriod();
   const windDirection = useWindDirection();
+  const weather = useWeather();
   const uxHints = useUxHints();
   const isMobile = useIsMobile();
   const [assetsLoaded, setAssetsLoaded] = useState(false);
@@ -244,6 +246,7 @@ const AppContent = () => {
               onMessageRead={uxHints.markBottleOpened}
               showHint={!isLoading && uxHints.shouldShowBottleHint}
               windDirection={windDirection}
+              weather={weather}
             />
           </Suspense>
           <Suspense fallback={null}>
@@ -253,7 +256,7 @@ const AppContent = () => {
 
           {/* 季節エフェクト */}
           <Suspense fallback={null}>
-            <MemoizedSeasonalEffects />
+            <MemoizedSeasonalEffects weather={weather} />
           </Suspense>
 
           {/* デバッグヘルパー - 削除 */}
@@ -274,7 +277,12 @@ const AppContent = () => {
           onAmbientToggle={uxHints.markAmbientToggled}
         />
         {/* 風向きコンパス - ローディング完了後のみ表示 */}
-        {!isLoading && <MemoizedWindDirectionDisplay windDirection={windDirection} />}
+        {!isLoading && (
+          <MemoizedWindDirectionDisplay
+            windDirection={windDirection}
+            weather={weather}
+          />
+        )}
       </div>
   );
 };

--- a/src/components/DriftingBottle/index.tsx
+++ b/src/components/DriftingBottle/index.tsx
@@ -13,6 +13,7 @@ import {
   type BottleJournalEntry,
   type WindDirection,
 } from "@/utils/bottleJournal";
+import type { WeatherSnapshot } from "@/utils/weather";
 import { BottleModel } from "./BottleModel";
 import { MessageCard } from "./MessageCard";
 
@@ -26,6 +27,8 @@ interface DriftingBottleProps {
   showHint?: boolean;
   /** 現在の風向き */
   windDirection?: WindDirection;
+  /** 現在の天気 */
+  weather: WeatherSnapshot;
 }
 
 /**
@@ -38,6 +41,7 @@ export const DriftingBottle = ({
   onMessageRead,
   showHint = false,
   windDirection = "East",
+  weather,
 }: DriftingBottleProps) => {
   const { season } = useSeason();
   const realTime = useClockTime();
@@ -61,8 +65,9 @@ export const DriftingBottle = ({
         season,
         timeOfDay: getTimeOfDay(realTime.hours),
         windDirection,
+        weather,
       }),
-    [realTime.hours, season, today, windDirection]
+    [realTime.hours, season, today, weather, windDirection]
   );
 
   // 1日1回、Gemini経由でメッセージを取得

--- a/src/components/SeasonalEffects.tsx
+++ b/src/components/SeasonalEffects.tsx
@@ -6,14 +6,19 @@ import FallenLeaves from './FallenLeaves';
 import SnowEffect from './SnowEffect';
 import RainEffect from './RainEffect';
 import { Fireflies } from './Fireflies';
+import { shouldShowRain, type WeatherSnapshot } from '@/utils/weather';
+
+interface SeasonalEffectsProps {
+  weather: WeatherSnapshot;
+}
 
 /**
  * 季節ごとのエフェクトを統合管理するコンポーネント
  */
-export const SeasonalEffects: React.FC = () => {
+export const SeasonalEffects: React.FC<SeasonalEffectsProps> = ({ weather }) => {
   const { season } = useSeason();
   const isDay = useDayPeriod();
-  const month = new Date().getMonth() + 1; // 1-12
+  const showRain = shouldShowRain(weather);
 
   return (
     <>
@@ -22,7 +27,7 @@ export const SeasonalEffects: React.FC = () => {
       {season === 'summer' && !isDay && <Fireflies />}
       {(season === 'autumn' || season === 'winter') && <FallenLeaves />}
       {season === 'winter' && <SnowEffect />}
-      {month === 6 && <RainEffect />}
+      {showRain && <RainEffect />}
     </>
   );
 };

--- a/src/components/WindDirectionDisplay.tsx
+++ b/src/components/WindDirectionDisplay.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { tokens } from '@/styles/tokens';
 import { useIsMobile } from '@/hooks/useIsMobile';
+import type { WeatherSnapshot } from '@/utils/weather';
 
 /** 風向き表示コンポーネントのプロパティ */
 interface WindDirectionDisplayProps {
   /** 風向き（北/東/南/西） */
   windDirection: "North" | "East" | "South" | "West";
+  /** 現在の天気 */
+  weather: WeatherSnapshot;
 }
 
 /** 風向きと表示情報のマッピング */
@@ -21,7 +24,10 @@ const windDirectionMap = {
  * 現在の風向きを視覚的に表示
  * @param props - コンポーネントのプロパティ
  */
-const WindDirectionDisplay: React.FC<WindDirectionDisplayProps> = ({ windDirection }) => {
+const WindDirectionDisplay: React.FC<WindDirectionDisplayProps> = ({
+  windDirection,
+  weather,
+}) => {
   const { rotation, kanji } = windDirectionMap[windDirection];
   const isMobile = useIsMobile();
 
@@ -215,6 +221,51 @@ const WindDirectionDisplay: React.FC<WindDirectionDisplayProps> = ({ windDirecti
         >
           の風
         </span>
+      </div>
+      <div
+        style={{
+          width: '100%',
+          paddingTop: tokens.spacing.sm,
+          borderTop: '1px solid rgba(255, 255, 255, 0.16)',
+          fontFamily: tokens.typography.fontFamily.serif,
+          textAlign: 'center',
+        }}
+      >
+        <div
+          style={{
+            fontSize: '18px',
+            fontWeight: 500,
+            color: 'rgba(255, 255, 255, 0.95)',
+            textShadow: '0 2px 4px rgba(0, 0, 0, 0.4)',
+          }}
+        >
+          {weather.label}
+        </div>
+        <div
+          style={{
+            marginTop: '2px',
+            fontSize: '11px',
+            fontWeight: 300,
+            color: 'rgba(255, 255, 255, 0.72)',
+            lineHeight: 1.5,
+            textShadow: '0 1px 2px rgba(0, 0, 0, 0.3)',
+          }}
+        >
+          {weather.description}
+        </div>
+        <div
+          style={{
+            marginTop: '2px',
+            fontSize: '10px',
+            fontWeight: 300,
+            color: 'rgba(255, 255, 255, 0.52)',
+            lineHeight: 1.4,
+          }}
+        >
+          {weather.source === 'open-meteo'
+            ? `${weather.location}の実天気`
+            : '水辺の天気'}
+        </div>
       </div>
     </div>
   );

--- a/src/constants/weather.ts
+++ b/src/constants/weather.ts
@@ -1,0 +1,14 @@
+/**
+ * 天気判定の定数
+ */
+
+export const WEATHER_REFRESH_INTERVAL_MS = 60 * 1000;
+export const WEATHER_TIME_BLOCK_HOURS = 3;
+export const WEATHER_SCORE_BUCKETS = 12;
+
+export const RAINY_SEASON_MONTH = 6;
+export const RAINY_SEASON_RAIN_THRESHOLD = 4;
+export const RAINY_SEASON_CLOUDY_THRESHOLD = 8;
+
+export const DEFAULT_RAIN_THRESHOLD = 1;
+export const DEFAULT_CLOUDY_THRESHOLD = 4;

--- a/src/hooks/useWeather.ts
+++ b/src/hooks/useWeather.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { WEATHER_REFRESH_INTERVAL_MS } from "@/constants/weather";
+import { fetchWeather, getFallbackWeather } from "@/utils/weather";
+
+/**
+ * 現在の擬似天気を管理する。
+ * 天気は日付と3時間帯から決定するため、リロードしても同じ時間帯は変わらない。
+ */
+export const useWeather = () => {
+  const [weather, setWeather] = useState(() => getFallbackWeather());
+
+  useEffect(() => {
+    let disposed = false;
+
+    const updateWeather = async () => {
+      const nextWeather = await fetchWeather();
+      if (!disposed) {
+        setWeather(nextWeather ?? getFallbackWeather());
+      }
+    };
+
+    updateWeather();
+
+    const interval = setInterval(updateWeather, WEATHER_REFRESH_INTERVAL_MS);
+
+    return () => {
+      disposed = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  return weather;
+};

--- a/src/utils/bottleJournal.ts
+++ b/src/utils/bottleJournal.ts
@@ -1,4 +1,5 @@
 import type { Season } from "@/contexts/SeasonContext/context";
+import type { WeatherSnapshot } from "@/utils/weather";
 import type { TimeOfDay } from "./time";
 
 export type WindDirection = "North" | "East" | "South" | "West";
@@ -16,6 +17,7 @@ interface LifeLogInput {
   season: Season;
   timeOfDay: TimeOfDay;
   windDirection: WindDirection;
+  weather: WeatherSnapshot;
 }
 
 const JOURNAL_STORAGE_KEY = "mizube_bottle_journal";
@@ -41,6 +43,21 @@ const windLabels: Record<WindDirection, string> = {
   South: "南",
   West: "西",
 };
+
+const weatherNotes = {
+  clear: [
+    "空は明るく、水面の光もよく届いていた",
+    "晴れた気配の中で、水の色が少し澄んで見えた",
+  ],
+  cloudy: [
+    "雲が光をやわらげ、水辺の影も静かだった",
+    "曇り空の下で、水面の反射が落ち着いていた",
+  ],
+  rain: [
+    "雨粒が落ちるたび、水面に小さな輪が増えた",
+    "雨の気配で、岸辺の音が少し近く聞こえた",
+  ],
+} as const;
 
 const seasonNotes: Record<Season, string[]> = {
   spring: [
@@ -93,7 +110,7 @@ const createSeed = (value: string) => {
   return hash >>> 0;
 };
 
-const pick = <T,>(items: T[], seed: number) => items[seed % items.length];
+const pick = <T,>(items: readonly T[], seed: number) => items[seed % items.length];
 
 export const getLocalDateKey = (date = new Date()) => {
   const year = date.getFullYear();
@@ -112,13 +129,19 @@ export const createDailyLifeLog = ({
   season,
   timeOfDay,
   windDirection,
+  weather,
 }: LifeLogInput) => {
-  const seed = createSeed(`${date}:${season}:${timeOfDay}:${windDirection}`);
+  const seed = createSeed(
+    `${date}:${season}:${timeOfDay}:${windDirection}:${weather.condition}`
+  );
   const seasonalText = pick(seasonNotes[season], seed);
   const timeText = pick(timeNotes[timeOfDay], seed >>> 3);
+  const weatherText = pick(weatherNotes[weather.condition], seed >>> 5);
+  const weatherSourceText =
+    weather.source === "open-meteo" ? `${weather.location}の${weather.label}。` : "";
   const windText = `${windLabels[windDirection]}からの風。`;
 
-  return `${formatJournalDate(date)}、${seasonLabels[season]}の${timeLabels[timeOfDay]}。${seasonalText}。${timeText}。${windText}`;
+  return `${formatJournalDate(date)}、${seasonLabels[season]}の${timeLabels[timeOfDay]}。${weatherSourceText}${seasonalText}。${weatherText}。${timeText}。${windText}`;
 };
 
 export const loadBottleJournal = (): BottleJournalEntry[] => {

--- a/src/utils/weather.ts
+++ b/src/utils/weather.ts
@@ -1,0 +1,117 @@
+import {
+  DEFAULT_CLOUDY_THRESHOLD,
+  DEFAULT_RAIN_THRESHOLD,
+  RAINY_SEASON_CLOUDY_THRESHOLD,
+  RAINY_SEASON_MONTH,
+  RAINY_SEASON_RAIN_THRESHOLD,
+  WEATHER_SCORE_BUCKETS,
+  WEATHER_TIME_BLOCK_HOURS,
+} from "@/constants/weather";
+
+export type WeatherCondition = "clear" | "cloudy" | "rain";
+
+export interface WeatherSnapshot {
+  condition: WeatherCondition;
+  label: string;
+  description: string;
+  observedAt: Date;
+  source: "open-meteo" | "fallback";
+  location: string;
+}
+
+interface WeatherApiResponse {
+  condition: WeatherCondition;
+  label: string;
+  description: string;
+  observedAt: string;
+  source: "open-meteo";
+  location: string;
+}
+
+const weatherLabels: Record<WeatherCondition, string> = {
+  clear: "晴",
+  cloudy: "曇",
+  rain: "雨",
+};
+
+const weatherDescriptions: Record<WeatherCondition, string> = {
+  clear: "水面がよく光る",
+  cloudy: "光がやわらぐ",
+  rain: "雨粒が落ちる",
+};
+
+const getJapanDate = (date: Date) =>
+  new Date(date.toLocaleString("en-US", { timeZone: "Asia/Tokyo" }));
+
+const getWeatherScore = (date: Date) => {
+  const japanDate = getJapanDate(date);
+  const year = japanDate.getFullYear();
+  const month = japanDate.getMonth() + 1;
+  const day = japanDate.getDate();
+  const timeBlock = Math.floor(japanDate.getHours() / WEATHER_TIME_BLOCK_HOURS);
+
+  return {
+    month,
+    score:
+      (year + month * 11 + day * 37 + timeBlock * 17) %
+      WEATHER_SCORE_BUCKETS,
+  };
+};
+
+export const getFallbackWeather = (date = new Date()): WeatherSnapshot => {
+  const { month, score } = getWeatherScore(date);
+  const rainThreshold =
+    month === RAINY_SEASON_MONTH
+      ? RAINY_SEASON_RAIN_THRESHOLD
+      : DEFAULT_RAIN_THRESHOLD;
+  const cloudyThreshold =
+    month === RAINY_SEASON_MONTH
+      ? RAINY_SEASON_CLOUDY_THRESHOLD
+      : DEFAULT_CLOUDY_THRESHOLD;
+
+  const condition: WeatherCondition =
+    score < rainThreshold
+      ? "rain"
+      : score < cloudyThreshold
+        ? "cloudy"
+        : "clear";
+
+  return {
+    condition,
+    label: weatherLabels[condition],
+    description: weatherDescriptions[condition],
+    observedAt: getJapanDate(date),
+    source: "fallback",
+    location: "水辺",
+  };
+};
+
+export const fetchWeather = async (): Promise<WeatherSnapshot | null> => {
+  try {
+    const response = await fetch("/api/weather");
+    if (!response.ok) {
+      return null;
+    }
+
+    const contentType = response.headers.get("content-type");
+    if (!contentType?.includes("application/json")) {
+      return null;
+    }
+
+    const data: WeatherApiResponse = await response.json();
+    return {
+      condition: data.condition,
+      label: data.label,
+      description: data.description,
+      observedAt: new Date(data.observedAt),
+      source: data.source,
+      location: data.location,
+    };
+  } catch (error) {
+    console.error("Error fetching weather:", error);
+    return null;
+  }
+};
+
+export const shouldShowRain = (weather: WeatherSnapshot) =>
+  weather.condition === "rain";


### PR DESCRIPTION
## 概要
- Open-Meteo の現在天気を Cloudflare Functions 経由で取得し、水辺の天気状態として使うようにしました。
- 雨エフェクトを6月固定表示から、実天気が雨の時だけ出る形に変更しました。
- 風向きカードと瓶の観察ログに天気情報を反映しました。

## 変更内容
- `functions/api/weather.ts` を追加し、東京の現在天気を取得
- `useWeather` と `weather` ユーティリティを追加し、API失敗時は擬似天気へフォールバック
- `SeasonalEffects` の雨表示条件を天気状態に変更
- `WindDirectionDisplay` に天気表示を追加
- `DriftingBottle` の観察ログへ天気由来の一文を追加

## テスト計画
- [x] Open-Meteo API レスポンス取得確認
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

🤖 Generated with [Codex CLI](https://openai.com/codex)