### PR TITLE
fix: 漂流瓶の便りカードを改善

### DIFF
--- a/src/components/DriftingBottle/MessageCard.tsx
+++ b/src/components/DriftingBottle/MessageCard.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import { Html } from "@react-three/drei";
-import { formatJournalDate, type BottleJournalEntry } from "@/utils/bottleJournal";
+import { useThree } from "@react-three/fiber";
+import { formatJournalDate, getBottleDiscoveryLabel } from "@/utils/bottleJournal";
 
 /** メッセージカードのプロパティ */
 interface MessageCardProps {
@@ -8,12 +9,8 @@ interface MessageCardProps {
   message: string;
   /** 送り主 */
   sender: string;
-  /** 今日の観察ログ */
-  lifeLog: string;
   /** 表示中の便りの日付 */
   currentDate: string;
-  /** 保存済みの便り履歴 */
-  journalEntries: BottleJournalEntry[];
   /** 閉じるボタンのクリックハンドラ */
   onClose: (e: React.MouseEvent) => void;
 }
@@ -21,23 +18,28 @@ interface MessageCardProps {
 /** カードのスタイル定義 */
 const CARD_STYLES = {
   container: {
-    background: "rgba(245, 230, 211, 0.98)",
-    padding: "20px",
+    background:
+      "linear-gradient(150deg, rgba(252, 239, 220, 0.98), rgba(238, 216, 186, 0.98))",
+    padding: "18px 20px 20px",
     borderRadius: "8px",
-    minWidth: "300px",
-    maxWidth: "400px",
-    maxHeight: "500px",
-    boxShadow: "0 4px 6px rgba(0, 0, 0, 0.3)",
+    width: "330px",
+    maxWidth: "calc(100vw - 32px)",
+    maxHeight: "min(74vh, 560px)",
+    boxSizing: "border-box" as const,
+    boxShadow:
+      "0 18px 42px rgba(20, 12, 4, 0.36), inset 0 1px 0 rgba(255, 255, 255, 0.6)",
     fontFamily: "'Noto Serif JP', serif",
     position: "relative" as const,
     border: "2px solid #d4a574",
     overflow: "hidden" as const,
     display: "flex",
     flexDirection: "column" as const,
+    color: "#4f422f",
   },
   content: {
     overflowY: "auto" as const,
     paddingRight: "4px",
+    overscrollBehavior: "contain" as const,
   },
   closeButton: {
     position: "absolute" as const,
@@ -56,18 +58,44 @@ const CARD_STYLES = {
     padding: "0",
   },
   title: {
-    margin: "0 0 15px 0",
+    margin: "0",
     color: "#5d4e37",
-    fontSize: "18px",
-    borderBottom: "1px solid #d4a574",
-    paddingBottom: "10px",
+    fontSize: "20px",
     flexShrink: 0,
+    letterSpacing: "0.08em",
+  },
+  header: {
+    position: "relative" as const,
+    marginBottom: "14px",
+    padding: "0 42px 13px 0",
+    borderBottom: "1px solid rgba(160, 112, 64, 0.44)",
+  },
+  eyebrow: {
+    margin: "0 0 5px 0",
+    color: "#9b744a",
+    fontSize: "11px",
+    letterSpacing: "0.18em",
+  },
+  statusRow: {
+    display: "flex",
+    flexWrap: "wrap" as const,
+    gap: "7px",
+    marginBottom: "16px",
+  },
+  statusChip: {
+    padding: "5px 9px",
+    borderRadius: "999px",
+    background: "rgba(255, 250, 239, 0.72)",
+    border: "1px solid rgba(178, 128, 75, 0.32)",
+    color: "#76583a",
+    fontSize: "11px",
+    letterSpacing: "0.04em",
   },
   message: {
     margin: "0",
-    lineHeight: "1.8",
+    lineHeight: "1.9",
     color: "#4a4a4a",
-    fontSize: "14px",
+    fontSize: "14.5px",
     whiteSpace: "pre-wrap" as const,
   },
   sender: {
@@ -77,54 +105,14 @@ const CARD_STYLES = {
     color: "#8b7355",
     fontStyle: "italic" as const,
   },
-  section: {
-    marginTop: "18px",
-    paddingTop: "14px",
-    borderTop: "1px solid rgba(139, 115, 85, 0.28)",
-  },
-  sectionTitle: {
-    margin: "0 0 8px 0",
-    color: "#5d4e37",
-    fontSize: "13px",
-    letterSpacing: "0.08em",
-  },
-  lifeLog: {
-    margin: "0",
-    color: "#5f5548",
-    fontSize: "12px",
-    lineHeight: "1.7",
-  },
-  historyList: {
-    display: "flex",
-    flexDirection: "column" as const,
-    gap: "10px",
-  },
-  historyItem: {
-    padding: "9px 10px",
-    borderRadius: "6px",
-    background: "rgba(255, 248, 235, 0.62)",
-    border: "1px solid rgba(212, 165, 116, 0.34)",
-  },
-  historyDate: {
-    margin: "0 0 4px 0",
+  footerNote: {
+    margin: "18px 0 0 0",
+    paddingTop: "12px",
+    borderTop: "1px dashed rgba(139, 115, 85, 0.28)",
     color: "#8b7355",
     fontSize: "11px",
-  },
-  historyText: {
-    margin: "0",
-    color: "#4f4a42",
-    fontSize: "12px",
     lineHeight: "1.6",
-    display: "-webkit-box",
-    WebkitLineClamp: 2,
-    WebkitBoxOrient: "vertical" as const,
-    overflow: "hidden",
-  },
-  emptyHistory: {
-    margin: "0",
-    color: "#8b7355",
-    fontSize: "12px",
-    lineHeight: "1.6",
+    textAlign: "center" as const,
   },
 };
 
@@ -135,46 +123,33 @@ const CARD_STYLES = {
 export const MessageCard = memo(({
   message,
   sender,
-  lifeLog,
   currentDate,
-  journalEntries,
   onClose,
 }: MessageCardProps) => {
-  const previousEntries = journalEntries.filter(
-    (entry) => entry.date !== currentDate
-  );
+  const discoveryLabel = getBottleDiscoveryLabel(currentDate);
+  const { size } = useThree();
+  const distanceFactor = size.width < 520 ? 6.2 : 10;
 
   return (
-    <Html center distanceFactor={10} style={{ pointerEvents: "all" }}>
+    <Html center distanceFactor={distanceFactor} style={{ pointerEvents: "all" }}>
       <div style={CARD_STYLES.container} onClick={(e) => e.stopPropagation()}>
         <button onClick={onClose} style={CARD_STYLES.closeButton}>
           ×
         </button>
-        <h3 style={CARD_STYLES.title}>海からの便り</h3>
+        <div style={CARD_STYLES.header}>
+          <p style={CARD_STYLES.eyebrow}>DRIFTING NOTE</p>
+          <h3 style={CARD_STYLES.title}>海からの便り</h3>
+        </div>
         <div style={CARD_STYLES.content}>
+          <div style={CARD_STYLES.statusRow}>
+            <span style={CARD_STYLES.statusChip}>{formatJournalDate(currentDate)}</span>
+            <span style={CARD_STYLES.statusChip}>今日のしるし: {discoveryLabel}</span>
+          </div>
           <p style={CARD_STYLES.message}>{message}</p>
           <div style={CARD_STYLES.sender}>— {sender}</div>
-          <section style={CARD_STYLES.section}>
-            <h4 style={CARD_STYLES.sectionTitle}>今日の観察</h4>
-            <p style={CARD_STYLES.lifeLog}>{lifeLog}</p>
-          </section>
-          <section style={CARD_STYLES.section}>
-            <h4 style={CARD_STYLES.sectionTitle}>これまでの便り</h4>
-            {previousEntries.length > 0 ? (
-              <div style={CARD_STYLES.historyList}>
-                {previousEntries.slice(0, 5).map((entry) => (
-                  <article key={entry.date} style={CARD_STYLES.historyItem}>
-                    <p style={CARD_STYLES.historyDate}>{formatJournalDate(entry.date)}</p>
-                    <p style={CARD_STYLES.historyText}>{entry.message}</p>
-                  </article>
-                ))}
-              </div>
-            ) : (
-              <p style={CARD_STYLES.emptyHistory}>
-                まだ過去の便りはありません。次に瓶を開くと、ここに記録が残ります。
-              </p>
-            )}
-          </section>
+          <p style={CARD_STYLES.footerNote}>
+            閉じると、今日のしるしが水面に残ります。
+          </p>
         </div>
       </div>
     </Html>

--- a/src/components/DriftingBottle/index.tsx
+++ b/src/components/DriftingBottle/index.tsx
@@ -1,5 +1,7 @@
-import { useMemo, useState, useEffect } from "react";
+import { useMemo, useRef, useState, useEffect } from "react";
 import { Html } from "@react-three/drei";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
 import { fetchDailyMessage } from "../../utils/dailyMessage";
 import { useBottleAnimation } from "../../hooks/useBottleAnimation";
 import { useIsMobile } from "@/hooks/useIsMobile";
@@ -7,15 +9,233 @@ import { useClockTime, useSeason } from "@/contexts";
 import { getTimeOfDay } from "@/utils/time";
 import {
   createDailyLifeLog,
+  getBottleDiscoveryLabel,
   getLocalDateKey,
   loadBottleJournal,
+  loadBottleMemorySigns,
+  saveBottleMemorySign,
   saveBottleJournalEntry,
   type BottleJournalEntry,
+  type BottleMemorySign,
   type WindDirection,
 } from "@/utils/bottleJournal";
 import type { WeatherSnapshot } from "@/utils/weather";
 import { BottleModel } from "./BottleModel";
 import { MessageCard } from "./MessageCard";
+
+interface BottleReadAfterglowProps {
+  onComplete: () => void;
+}
+
+const AFTERGLOW_LIFETIME = 3.2;
+
+const afterglowSeeds = [
+  { angle: 0.1, radius: 0.34, speed: 0.82, size: 0.034 },
+  { angle: 1.35, radius: 0.48, speed: 0.68, size: 0.026 },
+  { angle: 2.4, radius: 0.42, speed: 0.75, size: 0.03 },
+  { angle: 3.55, radius: 0.54, speed: 0.61, size: 0.024 },
+  { angle: 4.7, radius: 0.38, speed: 0.88, size: 0.028 },
+  { angle: 5.62, radius: 0.5, speed: 0.7, size: 0.022 },
+] as const;
+
+const BottleReadAfterglow = ({ onComplete }: BottleReadAfterglowProps) => {
+  const groupRef = useRef<THREE.Group>(null);
+  const ringMaterialRef = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        color: "#f7f0c2",
+        transparent: true,
+        opacity: 0,
+        depthWrite: false,
+        depthTest: false,
+        blending: THREE.AdditiveBlending,
+      }),
+    []
+  );
+  const coreMaterialRef = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        color: "#fff7c9",
+        transparent: true,
+        opacity: 0,
+        depthWrite: false,
+        depthTest: false,
+        blending: THREE.AdditiveBlending,
+      }),
+    []
+  );
+  const sparkleMaterialRef = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        color: "#cffff5",
+        transparent: true,
+        opacity: 0,
+        depthWrite: false,
+        depthTest: false,
+        blending: THREE.AdditiveBlending,
+      }),
+    []
+  );
+  const startedAtRef = useMemo(() => ({ value: null as number | null }), []);
+  const completedRef = useMemo(() => ({ value: false }), []);
+
+  useEffect(() => {
+    return () => {
+      ringMaterialRef.dispose();
+      coreMaterialRef.dispose();
+      sparkleMaterialRef.dispose();
+    };
+  }, [coreMaterialRef, ringMaterialRef, sparkleMaterialRef]);
+
+  useFrame((state) => {
+    if (!groupRef.current) {
+      return;
+    }
+
+    if (startedAtRef.value === null) {
+      startedAtRef.value = state.clock.getElapsedTime();
+    }
+
+    const age = state.clock.getElapsedTime() - startedAtRef.value;
+    const progress = Math.min(1, age / AFTERGLOW_LIFETIME);
+    const fade = Math.pow(1 - progress, 1.55);
+    const pulse = 0.82 + Math.sin(age * 5.4) * 0.18;
+
+    groupRef.current.scale.setScalar(1 + progress * 1.9);
+    groupRef.current.rotation.y = age * 0.22;
+    ringMaterialRef.opacity = fade * 0.28;
+    coreMaterialRef.opacity = fade * 0.18 * pulse;
+    sparkleMaterialRef.opacity = fade * 0.64;
+
+    if (progress >= 1 && !completedRef.value) {
+      completedRef.value = true;
+      onComplete();
+    }
+  });
+
+  return (
+    <group ref={groupRef} position={[0, -0.12, 0]} renderOrder={1003}>
+      <mesh rotation={[-Math.PI / 2, 0, 0]} scale={[0.52, 0.52, 1]}>
+        <ringGeometry args={[0.76, 0.79, 96]} />
+        <primitive object={ringMaterialRef} attach="material" />
+      </mesh>
+      <mesh rotation={[-Math.PI / 2, 0, 0]} scale={[0.18, 0.18, 1]}>
+        <circleGeometry args={[1, 32]} />
+        <primitive object={coreMaterialRef} attach="material" />
+      </mesh>
+      {afterglowSeeds.map((seed, index) => (
+        <mesh
+          key={index}
+          position={[
+            Math.cos(seed.angle) * seed.radius,
+            0.035 + index * 0.006,
+            Math.sin(seed.angle) * seed.radius,
+          ]}
+          rotation={[-Math.PI / 2, 0, seed.angle]}
+          scale={[seed.size, seed.size * (1.15 + seed.speed * 0.2), 1]}
+        >
+          <circleGeometry args={[1, 14]} />
+          <primitive object={sparkleMaterialRef} attach="material" />
+        </mesh>
+      ))}
+    </group>
+  );
+};
+
+interface BottleMemoryMarksProps {
+  signs: BottleMemorySign[];
+}
+
+const createSignSeed = (value: string) => {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+};
+
+const getSignPlacement = (date: string, index: number) => {
+  const seed = createSignSeed(date);
+  const angle = ((seed % 360) / 180) * Math.PI + index * 0.46;
+  const radius = 0.72 + ((seed >>> 4) % 5) * 0.12;
+  const size = 0.13 + ((seed >>> 8) % 4) * 0.016;
+  return { angle, radius, size };
+};
+
+const BottleMemoryMarks = ({ signs }: BottleMemoryMarksProps) => {
+  const groupRef = useRef<THREE.Group>(null);
+  const markMaterial = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        color: "#fff2a8",
+        transparent: true,
+        opacity: 0.62,
+        depthWrite: false,
+        depthTest: false,
+        blending: THREE.AdditiveBlending,
+      }),
+    []
+  );
+  const ringMaterial = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        color: "#f9ffd2",
+        transparent: true,
+        opacity: 0.28,
+        depthWrite: false,
+        depthTest: false,
+        blending: THREE.AdditiveBlending,
+      }),
+    []
+  );
+
+  useEffect(() => {
+    return () => {
+      markMaterial.dispose();
+      ringMaterial.dispose();
+    };
+  }, [markMaterial, ringMaterial]);
+
+  useFrame((state) => {
+    if (!groupRef.current || signs.length === 0) {
+      return;
+    }
+
+    const time = state.clock.getElapsedTime();
+    groupRef.current.rotation.y = Math.sin(time * 0.16) * 0.08;
+    markMaterial.opacity = 0.52 + Math.sin(time * 1.4) * 0.08;
+    ringMaterial.opacity = 0.24 + Math.sin(time * 0.9) * 0.05;
+  });
+
+  if (signs.length === 0) {
+    return null;
+  }
+
+  return (
+    <group ref={groupRef} position={[0, 0.86, 0]} renderOrder={996}>
+      {signs.slice(0, 7).map((sign, index) => {
+        const placement = getSignPlacement(sign.date, index);
+        const x = Math.cos(placement.angle) * placement.radius;
+        const z = Math.sin(placement.angle) * placement.radius;
+        const scale = placement.size * (1 - index * 0.045);
+
+        return (
+          <group key={sign.date} position={[x, 0.01 + index * 0.004, z]}>
+            <mesh rotation={[-Math.PI / 2, 0, placement.angle]} scale={[scale, scale * 1.55, 1]}>
+              <circleGeometry args={[1, 16]} />
+              <primitive object={markMaterial} attach="material" />
+            </mesh>
+            <mesh rotation={[-Math.PI / 2, 0, 0]} scale={[scale * 4.4, scale * 4.4, 1]}>
+              <ringGeometry args={[0.82, 1, 40]} />
+              <primitive object={ringMaterial} attach="material" />
+            </mesh>
+          </group>
+        );
+      })}
+    </group>
+  );
+};
 
 /** 漂流瓶のプロパティ */
 interface DriftingBottleProps {
@@ -51,7 +271,11 @@ export const DriftingBottle = ({
   const [currentSender, setCurrentSender] = useState("");
   const [displayedLifeLog, setDisplayedLifeLog] = useState("");
   const [dailyMessageFetched, setDailyMessageFetched] = useState(false);
-  const [journalEntries, setJournalEntries] = useState<BottleJournalEntry[]>(() =>
+  const [readAfterglowId, setReadAfterglowId] = useState(0);
+  const [memorySigns, setMemorySigns] = useState<BottleMemorySign[]>(() =>
+    loadBottleMemorySigns()
+  );
+  const [, setJournalEntries] = useState<BottleJournalEntry[]>(() =>
     loadBottleJournal()
   );
   const isMobile = useIsMobile();
@@ -79,7 +303,9 @@ export const DriftingBottle = ({
         setCurrentSender("海からの便り");
       } else {
         // APIが失敗した場合のフォールバック
-        setCurrentMessage("今日の海は静かで、便りはまだ届いていません。\n\nまた明日、お越しください。");
+        setCurrentMessage(
+          "瓶の中の紙は、まだ少し湿っています。\n\n文字は読めないけれど、縁に残った潮の跡だけが今日の水辺を覚えています。"
+        );
         setCurrentSender("海からの便り");
       }
     };
@@ -115,6 +341,14 @@ export const DriftingBottle = ({
   const handleCloseMessage = (e: React.MouseEvent) => {
     e.stopPropagation();
     setShowMessage(false);
+    setMemorySigns(
+      saveBottleMemorySign({
+        date: today,
+        label: getBottleDiscoveryLabel(today),
+        readAt: new Date().toISOString(),
+      })
+    );
+    setReadAfterglowId((id) => id + 1);
   };
 
   return (
@@ -126,6 +360,7 @@ export const DriftingBottle = ({
       onPointerOut={() => setHovered(false)}
     >
       <BottleModel hovered={hovered} />
+      <BottleMemoryMarks signs={memorySigns} />
       {showHint && !showMessage && (
         <Html position={[0, 1.3, 0]} center distanceFactor={10} style={{ pointerEvents: "none" }}>
           <div
@@ -152,10 +387,14 @@ export const DriftingBottle = ({
         <MessageCard
           message={currentMessage}
           sender={currentSender}
-          lifeLog={displayedLifeLog || lifeLog}
           currentDate={today}
-          journalEntries={journalEntries}
           onClose={handleCloseMessage}
+        />
+      )}
+      {readAfterglowId > 0 && (
+        <BottleReadAfterglow
+          key={readAfterglowId}
+          onComplete={() => setReadAfterglowId(0)}
         />
       )}
     </group>

--- a/src/utils/bottleJournal.ts
+++ b/src/utils/bottleJournal.ts
@@ -12,6 +12,12 @@ export interface BottleJournalEntry {
   readAt: string;
 }
 
+export interface BottleMemorySign {
+  date: string;
+  label: string;
+  readAt: string;
+}
+
 interface LifeLogInput {
   date: string;
   season: Season;
@@ -21,7 +27,9 @@ interface LifeLogInput {
 }
 
 const JOURNAL_STORAGE_KEY = "mizube_bottle_journal";
+const MEMORY_SIGNS_STORAGE_KEY = "mizube_bottle_memory_signs";
 const MAX_JOURNAL_ENTRIES = 14;
+const MAX_MEMORY_SIGNS = 10;
 
 const seasonLabels: Record<Season, string> = {
   spring: "春",
@@ -58,6 +66,13 @@ const weatherNotes = {
     "雨の気配で、岸辺の音が少し近く聞こえた",
   ],
 } as const;
+
+const discoveryLabels = [
+  "波紋の発見",
+  "風向きのしるし",
+  "光の漂着",
+  "水面の記録",
+] as const;
 
 const seasonNotes: Record<Season, string[]> = {
   spring: [
@@ -111,6 +126,9 @@ const createSeed = (value: string) => {
 };
 
 const pick = <T,>(items: readonly T[], seed: number) => items[seed % items.length];
+
+export const getBottleDiscoveryLabel = (date: string) =>
+  pick(discoveryLabels, createSeed(date));
 
 export const getLocalDateKey = (date = new Date()) => {
   const year = date.getFullYear();
@@ -188,4 +206,48 @@ export const saveBottleJournalEntry = (entry: BottleJournalEntry) => {
 
   window.localStorage.setItem(JOURNAL_STORAGE_KEY, JSON.stringify(nextJournal));
   return nextJournal;
+};
+
+export const loadBottleMemorySigns = (): BottleMemorySign[] => {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const rawSigns = window.localStorage.getItem(MEMORY_SIGNS_STORAGE_KEY);
+    if (!rawSigns) {
+      return [];
+    }
+
+    const parsed = JSON.parse(rawSigns);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter(
+      (sign): sign is BottleMemorySign =>
+        typeof sign?.date === "string" &&
+        typeof sign?.label === "string" &&
+        typeof sign?.readAt === "string"
+    );
+  } catch (error) {
+    console.error("Error loading bottle memory signs:", error);
+    return [];
+  }
+};
+
+export const saveBottleMemorySign = (sign: BottleMemorySign) => {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  const withoutSameDate = loadBottleMemorySigns().filter(
+    (storedSign) => storedSign.date !== sign.date
+  );
+  const nextSigns = [sign, ...withoutSameDate]
+    .sort((a, b) => b.date.localeCompare(a.date))
+    .slice(0, MAX_MEMORY_SIGNS);
+
+  window.localStorage.setItem(MEMORY_SIGNS_STORAGE_KEY, JSON.stringify(nextSigns));
+  return nextSigns;
 };

--- a/tmp/027_issue-70-bottle-letter-polish/plan.md
+++ b/tmp/027_issue-70-bottle-letter-polish/plan.md
@@ -1,0 +1,65 @@
+# 実装計画: issue-70-bottle-letter-polish
+
+## Issue
+- #70: なんかつまんない
+- URL: https://github.com/andsaki/biotope/issues/70
+- 添付画像を確認済み
+
+## 目的
+漂流瓶を開いた時の便りカードが、説明文と履歴の羅列に見えて体験として単調になっている。
+カード内に情報を詰めるのではなく、手紙は短く読ませ、閉じた後に水面へ小さな変化が残るようにして「読んだ意味」を画面側へ返す。
+
+## 実装スコープ
+### 1. 作成するファイル
+- なし
+
+### 2. 変更するファイル
+- `src/components/DriftingBottle/MessageCard.tsx`
+  - 便りカードを短い本文と今日のしるしだけに絞る。
+  - 履歴・観察ログの表示はカードから外し、保存処理だけ維持する。
+- `src/components/DriftingBottle/index.tsx`
+  - API 失敗時のフォールバック文言を、空通知ではなく便りとして読める文面に変更する。
+  - 便りを閉じた後、水面に光の輪と粒が数秒残る演出を追加する。
+- `src/utils/bottleJournal.ts`
+  - 今日のしるしを localStorage に保存し、次回以降も瓶の周辺に蓄積表示できるようにする。
+- `tmp/027_issue-70-bottle-letter-polish/prompt.md`
+  - 実装内容と検証結果を記録する。
+
+## 実装手順（ステップバイステップ）
+1. 既存の `MessageCard` と `bottleJournal` の責務を確認する。
+2. カードは日付、今日のしるし、本文、送り主だけに絞る。
+3. 履歴セクションと観察ログの表示をカードから外す。
+4. 便りを閉じた時にだけ発火する読後演出を `DriftingBottle` に追加する。
+5. 今日のしるしを保存し、過去分を瓶の周辺に小さな光として表示する。
+6. モバイル幅でカードがはみ出さないよう、inline style の幅・余白・スケールを調整する。
+7. `npm run build`、`npx tsc --noEmit`、`npm run lint` を実行する。
+8. Playwright または Chrome で desktop/mobile 表示を確認する。
+
+## 技術的詳細
+- 新しい依存関係は追加しない。
+- 既存の `Html` ベースの 3D 内 UI を維持する。
+- `MessageCard` 内の inline style 方式を踏襲し、CSS ファイルへの大きな移動は行わない。
+- 保存済み journal のスキーマは変更しない。既存 localStorage データと互換性を保つ。
+- Gemini/API の取得ロジックは変更しない。
+- 読後演出は `THREE.MeshBasicMaterial` と既存の `useFrame` だけで実装し、新しい依存関係は追加しない。
+- 保存済みのしるしは日付ごとに1件にまとめ、最大10件まで保持する。
+
+## テスト計画
+- [x] `npx tsc --noEmit`
+- [x] `npm run lint`
+- [x] `npm run build`
+- [x] desktop viewport で瓶の便りカードを確認
+- [x] mobile viewport で瓶の便りカードを確認
+- [x] 実アプリの初期描画が非blankであることを確認
+- [x] localStorage に保存済みしるしを入れた状態で実アプリを確認
+
+## 完了条件
+- [x] 便りカードが添付画像より単調に見えない
+- [x] カード内の情報量が小さい紙面に対して過剰ではない
+- [x] 便りを閉じた後に水辺側へ変化が残る
+- [x] 今日のしるしが次回以降も水辺に蓄積される
+- [x] 既存 journal localStorage との互換性を壊していない
+- [x] 型チェック、lint、build が通る
+
+## 実装時間見積もり
+合計: 45分

--- a/tmp/027_issue-70-bottle-letter-polish/prompt.md
+++ b/tmp/027_issue-70-bottle-letter-polish/prompt.md
@@ -1,0 +1,44 @@
+# 実装セッション: issue-70-bottle-letter-polish
+
+## セッション情報
+- 開始日時: 2026-06-21
+- Issue: https://github.com/andsaki/biotope/issues/70
+- タスク: 漂流瓶の便りカードを単調に見えないよう改善する
+- 参照: plan.md
+- 添付画像: 確認済み
+
+## 進捗状況
+### 完了
+- [x] Issue #70 の内容確認
+- [x] 添付画像確認
+- [x] plan.md 作成
+- [x] prompt.md 作成
+- [x] 便りカードを短い本文と今日のしるしに削減
+- [x] 履歴セクションと観察ログ表示をカードから削除
+- [x] 便りを閉じた後に水面へ光の輪と粒が残る演出を追加
+- [x] 今日のしるしを localStorage に保存し、次回以降も瓶の周辺に蓄積表示
+- [x] API 失敗時のフォールバックメッセージを改善
+- [x] コミット作成
+- [x] PR 作成: https://github.com/andsaki/biotope/pull/71
+
+### 検証
+- [x] `npx tsc --noEmit`
+- [x] `npm run lint`
+- [x] `npm run build`
+- [x] Playwright + Google Chrome で desktop/mobile のカード表示を確認
+- [x] Playwright + Google Chrome で実アプリの初期描画を確認
+- [x] localStorage に保存済みしるしを入れた状態で実アプリを確認
+
+## ユーザーからの指示
+- 2026-06-21: 「https://github.com/andsaki/biotope/issues/70やって」
+
+## メモ
+- Issue 本文は画像のみ。添付画像では `海からの便り` カードが単調に見える。
+- 実装対象は `src/components/DriftingBottle/MessageCard.tsx` を中心にする。
+- 既存 journal localStorage のスキーマは変更しない。
+- 一度はカード内に履歴・観察・発見カードを足したが、小さい紙面に詰め込みすぎるため削減。
+- `MessageCard` は `DRIFTING NOTE` の導入、日付、今日のしるし、本文、送り主だけにする。
+- `DriftingBottle` の API 失敗時文言を、空通知ではなく情緒のある漂着メッセージに変更。
+- モバイルでは `Html` の `distanceFactor` が大きく出すぎたため、Canvas 幅に応じてスケールを下げるよう調整。
+- 便りを閉じた後、瓶の周辺に光の輪と粒が数秒残る `BottleReadAfterglow` を追加。
+- `mizube_bottle_memory_signs` に日付ごとのしるしを最大10件保存し、`BottleMemoryMarks` で蓄積した光として表示。


### PR DESCRIPTION
## Summary
- 便りカードを短い本文と日付/今日のしるしだけに削り、カード内の詰め込みを解消
- API失敗時フォールバック文言を、空通知ではなく便りとして読める文面に変更
- 便りを閉じた後、瓶の周辺に光の輪と粒が数秒残る読後演出を追加
- 今日のしるしを localStorage に保存し、次回以降も瓶の周辺に蓄積した光として表示
- 既存 journal localStorage の保存スキーマは維持

## Tests
- npx tsc --noEmit
- npm run lint
- npm run build
- Playwright + Google Chrome で desktop/mobile のカード表示を確認
- Playwright + Google Chrome で実アプリの初期描画を確認
- localStorage に保存済みしるしを入れた状態で実アプリを確認

Closes #70