### PR TITLE
fix: 便りカードの閉じるボタンを修正

### DIFF
--- a/src/components/DriftingBottle/MessageCard.tsx
+++ b/src/components/DriftingBottle/MessageCard.tsx
@@ -12,8 +12,18 @@ interface MessageCardProps {
   /** 表示中の便りの日付 */
   currentDate: string;
   /** 閉じるボタンのクリックハンドラ */
-  onClose: (e: React.MouseEvent) => void;
+  onClose: () => void;
 }
+
+type CardPointerEvent =
+  | React.MouseEvent<HTMLElement>
+  | React.PointerEvent<HTMLElement>;
+
+const stopCardEvent = (event: CardPointerEvent) => {
+  event.preventDefault();
+  event.stopPropagation();
+  event.nativeEvent.stopImmediatePropagation();
+};
 
 /** カードのスタイル定義 */
 const CARD_STYLES = {
@@ -35,6 +45,7 @@ const CARD_STYLES = {
     display: "flex",
     flexDirection: "column" as const,
     color: "#4f422f",
+    userSelect: "none" as const,
   },
   content: {
     overflowY: "auto" as const,
@@ -56,6 +67,10 @@ const CARD_STYLES = {
     alignItems: "center",
     justifyContent: "center",
     padding: "0",
+    lineHeight: "1",
+    zIndex: 2,
+    pointerEvents: "auto" as const,
+    touchAction: "manipulation" as const,
   },
   title: {
     margin: "0",
@@ -129,11 +144,32 @@ export const MessageCard = memo(({
   const discoveryLabel = getBottleDiscoveryLabel(currentDate);
   const { size } = useThree();
   const distanceFactor = size.width < 520 ? 6.2 : 10;
+  const handleClose = (event: React.MouseEvent<HTMLButtonElement>) => {
+    stopCardEvent(event);
+    onClose();
+  };
+  const handleClosePointerDown = (event: React.PointerEvent<HTMLButtonElement>) => {
+    stopCardEvent(event);
+  };
+  const stopContainerEvent = (event: CardPointerEvent) => {
+    event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
+  };
 
   return (
     <Html center distanceFactor={distanceFactor} style={{ pointerEvents: "all" }}>
-      <div style={CARD_STYLES.container} onClick={(e) => e.stopPropagation()}>
-        <button onClick={onClose} style={CARD_STYLES.closeButton}>
+      <div
+        style={CARD_STYLES.container}
+        onClick={stopContainerEvent}
+        onPointerDown={stopContainerEvent}
+      >
+        <button
+          type="button"
+          onClick={handleClose}
+          onPointerDown={handleClosePointerDown}
+          style={CARD_STYLES.closeButton}
+          aria-label="便りを閉じる"
+        >
           ×
         </button>
         <div style={CARD_STYLES.header}>

--- a/src/components/DriftingBottle/index.tsx
+++ b/src/components/DriftingBottle/index.tsx
@@ -338,8 +338,7 @@ export const DriftingBottle = ({
     setJournalEntries(nextJournal);
   }, [currentMessage, currentSender, displayedLifeLog, showMessage, today]);
 
-  const handleCloseMessage = (e: React.MouseEvent) => {
-    e.stopPropagation();
+  const handleCloseMessage = () => {
     setShowMessage(false);
     setMemorySigns(
       saveBottleMemorySign({

--- a/tmp/028_fix-message-card-close/plan.md
+++ b/tmp/028_fix-message-card-close/plan.md
@@ -1,0 +1,20 @@
+# 実装計画: fix-message-card-close
+
+## Issue
+- メッセージカード右上の閉じるボタンが押せない。
+
+## 目的
+`Html` で表示している便りカード内のクリックが 3D Canvas 側へ伝播したり、テキスト選択に吸われたりして閉じられない状態を解消する。
+
+## 変更するファイル
+- `src/components/DriftingBottle/MessageCard.tsx`
+  - 閉じるボタンの pointer/click イベントで DOM 伝播を停止する。
+  - 閉じるボタンを最前面かつ操作可能にする。
+- `src/components/DriftingBottle/index.tsx`
+  - close handler をイベント非依存にする。
+
+## テスト計画
+- [x] `npx tsc --noEmit`
+- [x] `npm run lint`
+- [x] `npm run build`
+- [x] Playwright + Google Chrome で閉じるボタンの動作確認

--- a/tmp/028_fix-message-card-close/prompt.md
+++ b/tmp/028_fix-message-card-close/prompt.md
@@ -1,0 +1,18 @@
+# 実装セッション: fix-message-card-close
+
+## セッション情報
+- 開始日時: 2026-06-22
+- タスク: メッセージカードの閉じるボタンを押せるようにする
+
+## 完了
+- [x] `MessageCard` の `onClose` をイベント非依存に変更
+- [x] 閉じるボタンで `pointerDown` と `click` の伝播を停止
+- [x] カード全体の pointer/click 伝播を停止
+- [x] 閉じるボタンに `type` と `aria-label` を追加
+- [x] `DriftingBottle` 側の close handler をイベント非依存に変更
+
+## 検証
+- [x] `npx tsc --noEmit`
+- [x] `npm run lint`
+- [x] `npm run build`
+- [x] Playwright + Google Chrome で `before: true` / `after: false` を確認


### PR DESCRIPTION
## Summary
- MessageCard の閉じる処理をイベント非依存に変更
- 閉じるボタンの pointer/click イベントで DOM 伝播を停止
- カード全体の pointer/click 伝播を止め、3D Canvas 側のクリック再発火を防止
- 閉じるボタンに type と aria-label を追加

## Tests
- npx tsc --noEmit
- npm run lint
- npm run build
- Playwright + Google Chrome で閉じるボタンクリック後にカードDOMが消えることを確認