### PR TITLE
fix: 天気APIの東京固定をやめる

### DIFF
--- a/functions/api/weather.ts
+++ b/functions/api/weather.ts
@@ -1,6 +1,6 @@
 /**
  * Cloudflare Functions - 現在の天気API
- * Open-Meteoから東京の現在天気を取得する
+ * Cloudflare のリクエスト位置情報を使って Open-Meteo から現在天気を取得する
  */
 
 /// <reference types="@cloudflare/workers-types" />
@@ -14,21 +14,45 @@ interface OpenMeteoCurrent {
   snowfall: number;
   cloud_cover: number;
   wind_direction_10m: number;
+  wind_speed_10m: number;
+}
+
+interface OpenMeteoHourly {
+  time: string[];
+  weather_code: number[];
+  precipitation_probability?: number[];
+  precipitation: number[];
+  rain: number[];
+  showers: number[];
+  snowfall: number[];
+  cloud_cover: number[];
+  wind_direction_10m: number[];
+  wind_speed_10m: number[];
 }
 
 interface OpenMeteoResponse {
   current: OpenMeteoCurrent;
+  hourly?: OpenMeteoHourly;
 }
 
 type WeatherCondition = "clear" | "cloudy" | "rain";
 
-const TOKYO_STATION = {
-  name: "東京",
-  latitude: 35.6812,
-  longitude: 139.7671,
-} as const;
+interface RequestLocation {
+  name: string;
+  latitude: number;
+  longitude: number;
+}
+
+interface CloudflareGeo {
+  city?: unknown;
+  region?: unknown;
+  country?: unknown;
+  latitude?: unknown;
+  longitude?: unknown;
+}
 
 const CACHE_TTL_SECONDS = 30 * 60;
+const FORECAST_HOURS = 6;
 
 const WEATHER_LABELS: Record<WeatherCondition, string> = {
   clear: "晴",
@@ -37,9 +61,9 @@ const WEATHER_LABELS: Record<WeatherCondition, string> = {
 };
 
 const WEATHER_DESCRIPTIONS: Record<WeatherCondition, string> = {
-  clear: "東京の空が明るい",
-  cloudy: "東京の光がやわらぐ",
-  rain: "東京に雨が降る",
+  clear: "近くの空が明るい",
+  cloudy: "近くの光がやわらぐ",
+  rain: "近くに雨が降る",
 };
 
 const rainyWeatherCodes = new Set([
@@ -64,6 +88,75 @@ const getCondition = (current: OpenMeteoCurrent): WeatherCondition => {
   return "clear";
 };
 
+const getHourlyCondition = ({
+  weatherCode,
+  precipitation,
+  cloudCover,
+}: {
+  weatherCode: number;
+  precipitation: number;
+  cloudCover: number;
+}): WeatherCondition => {
+  if (precipitation > 0 || rainyWeatherCodes.has(weatherCode)) {
+    return "rain";
+  }
+
+  if (cloudCover >= 55 || cloudyWeatherCodes.has(weatherCode)) {
+    return "cloudy";
+  }
+
+  return "clear";
+};
+
+const sumPrecipitation = ({
+  precipitation,
+  rain,
+  showers,
+  snowfall,
+}: {
+  precipitation: number;
+  rain: number;
+  showers: number;
+  snowfall: number;
+}) => precipitation + rain + showers + snowfall;
+
+const getStringValue = (value: unknown) =>
+  typeof value === "string" && value.trim() ? value.trim() : null;
+
+const getNumberValue = (value: unknown) => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+};
+
+const getRequestLocation = (request: Request): RequestLocation | null => {
+  const cf = request.cf as CloudflareGeo | undefined;
+  const latitude = getNumberValue(cf?.latitude);
+  const longitude = getNumberValue(cf?.longitude);
+
+  if (latitude === null || longitude === null) {
+    return null;
+  }
+
+  const city = getStringValue(cf?.city);
+  const region = getStringValue(cf?.region);
+  const country = getStringValue(cf?.country);
+  const name = city ?? region ?? country ?? "現在地";
+
+  return {
+    name,
+    latitude,
+    longitude,
+  };
+};
+
 export const onRequest = async (context: EventContext<unknown, string, Record<string, unknown>>) => {
   const corsHeaders = {
     "Access-Control-Allow-Origin": "*",
@@ -76,9 +169,20 @@ export const onRequest = async (context: EventContext<unknown, string, Record<st
   }
 
   try {
+    const location = getRequestLocation(context.request);
+    if (!location) {
+      return new Response(null, {
+        status: 204,
+        headers: {
+          ...corsHeaders,
+          "Cache-Control": "no-store",
+        },
+      });
+    }
+
     const apiUrl = new URL("https://api.open-meteo.com/v1/forecast");
-    apiUrl.searchParams.set("latitude", String(TOKYO_STATION.latitude));
-    apiUrl.searchParams.set("longitude", String(TOKYO_STATION.longitude));
+    apiUrl.searchParams.set("latitude", String(location.latitude));
+    apiUrl.searchParams.set("longitude", String(location.longitude));
     apiUrl.searchParams.set(
       "current",
       [
@@ -89,10 +193,26 @@ export const onRequest = async (context: EventContext<unknown, string, Record<st
         "snowfall",
         "cloud_cover",
         "wind_direction_10m",
+        "wind_speed_10m",
       ].join(",")
     );
-    apiUrl.searchParams.set("timezone", "Asia/Tokyo");
+    apiUrl.searchParams.set(
+      "hourly",
+      [
+        "weather_code",
+        "precipitation_probability",
+        "precipitation",
+        "rain",
+        "showers",
+        "snowfall",
+        "cloud_cover",
+        "wind_direction_10m",
+        "wind_speed_10m",
+      ].join(",")
+    );
+    apiUrl.searchParams.set("timezone", "auto");
     apiUrl.searchParams.set("forecast_days", "1");
+    apiUrl.searchParams.set("forecast_hours", String(FORECAST_HOURS));
 
     const response = await fetch(apiUrl.toString(), {
       headers: {
@@ -111,6 +231,39 @@ export const onRequest = async (context: EventContext<unknown, string, Record<st
     const data: OpenMeteoResponse = await response.json();
     const current = data.current;
     const condition = getCondition(current);
+    const currentPrecipitation = sumPrecipitation({
+      precipitation: current.precipitation,
+      rain: current.rain,
+      showers: current.showers,
+      snowfall: current.snowfall,
+    });
+    const hourly = data.hourly;
+    const forecast = hourly?.time.map((time, index) => {
+      const precipitation = sumPrecipitation({
+        precipitation: hourly.precipitation[index] ?? 0,
+        rain: hourly.rain[index] ?? 0,
+        showers: hourly.showers[index] ?? 0,
+        snowfall: hourly.snowfall[index] ?? 0,
+      });
+      const cloudCover = hourly.cloud_cover[index] ?? 0;
+      const hourlyCondition = getHourlyCondition({
+        weatherCode: hourly.weather_code[index] ?? 0,
+        precipitation,
+        cloudCover,
+      });
+
+      return {
+        time,
+        condition: hourlyCondition,
+        label: WEATHER_LABELS[hourlyCondition],
+        description: WEATHER_DESCRIPTIONS[hourlyCondition],
+        precipitation,
+        precipitationProbability: hourly.precipitation_probability?.[index] ?? null,
+        cloudCover,
+        windDirection: hourly.wind_direction_10m[index] ?? 0,
+        windSpeed: hourly.wind_speed_10m[index] ?? 0,
+      };
+    }) ?? [];
 
     return new Response(
       JSON.stringify({
@@ -119,12 +272,13 @@ export const onRequest = async (context: EventContext<unknown, string, Record<st
         description: WEATHER_DESCRIPTIONS[condition],
         observedAt: current.time,
         source: "open-meteo",
-        location: TOKYO_STATION.name,
+        location: location.name,
         weatherCode: current.weather_code,
         cloudCover: current.cloud_cover,
-        precipitation:
-          current.precipitation + current.rain + current.showers + current.snowfall,
+        precipitation: currentPrecipitation,
         windDirection: current.wind_direction_10m,
+        windSpeed: current.wind_speed_10m,
+        forecast,
         cacheTtl: CACHE_TTL_SECONDS,
       }),
       {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,9 +38,25 @@ import { useIsMobile } from "./hooks/useIsMobile";
 import { useWindDirection } from "./hooks/useWindDirection";
 import { useWeather } from "./hooks/useWeather";
 import { useUxHints } from "./hooks/useUxHints";
+import type { WindDirection } from "./utils/bottleJournal";
 
 // const DEBUG_MODE = false; // デバッグヘルパーの表示切替 - 削除
 const PERFORMANCE_MONITOR = import.meta.env.DEV; // 開発モードで自動的に有効化
+
+const getWindDirectionFromDegrees = (
+  degrees: number | null,
+  fallback: WindDirection
+): WindDirection => {
+  if (degrees === null || !Number.isFinite(degrees)) {
+    return fallback;
+  }
+
+  const normalized = ((degrees % 360) + 360) % 360;
+  if (normalized >= 315 || normalized < 45) return "North";
+  if (normalized < 135) return "East";
+  if (normalized < 225) return "South";
+  return "West";
+};
 
 // メモ化されたコンポーネント
 const MemoizedGround = memo(Ground);
@@ -93,8 +109,12 @@ type AppStyle = React.CSSProperties & { "--app-background-color"?: string };
  */
 const AppContent = () => {
   const isDay = useDayPeriod();
-  const windDirection = useWindDirection();
+  const simulatedWindDirection = useWindDirection();
   const weather = useWeather();
+  const windDirection = useMemo(
+    () => getWindDirectionFromDegrees(weather.windDirection, simulatedWindDirection),
+    [simulatedWindDirection, weather.windDirection]
+  );
   const uxHints = useUxHints();
   const isMobile = useIsMobile();
   const [assetsLoaded, setAssetsLoaded] = useState(false);
@@ -212,6 +232,7 @@ const AppContent = () => {
             ambientLightRef={ambientLightRef}
             pointLightRef={pointLightRef}
             spotLightRef={spotLightRef}
+            weather={weather}
           />
 
           {/* 太陽 */}
@@ -229,13 +250,16 @@ const AppContent = () => {
 
           {/* 初期表示の核になる軽量オブジェクト */}
           <MemoizedGround />
-          <MemoizedWaterSurface onInteract={uxHints.markWaterRippled} />
+          <MemoizedWaterSurface
+            weather={weather}
+            onInteract={uxHints.markWaterRippled}
+          />
           <MemoizedSundialGnomon />
           <MemoizedSundialBase />
 
           {/* モデル・装飾系は初期描画をブロックしない */}
           <Suspense fallback={null}>
-            <MemoizedFishManager />
+            <MemoizedFishManager weather={weather} />
           </Suspense>
           <Suspense fallback={null}>
             <WaterPlantsLarge />
@@ -254,7 +278,10 @@ const AppContent = () => {
           </Suspense>
           <Suspense fallback={null}>
             <MemoizedParticleLayerInstanced />
-            <MemoizedClouds timeScale={SIMULATED_SECONDS_PER_REAL_SECOND / 60} />
+            <MemoizedClouds
+              weather={weather}
+              timeScale={SIMULATED_SECONDS_PER_REAL_SECOND / 60}
+            />
           </Suspense>
 
           {/* 季節エフェクト */}

--- a/src/components/Clouds.tsx
+++ b/src/components/Clouds.tsx
@@ -37,6 +37,11 @@ import {
   CLOUD_EMISSIVE_COLOR,
   CLOUD_EMISSIVE_INTENSITY,
 } from '../constants/clouds';
+import {
+  getCloudIntensity,
+  getRainIntensity,
+  type WeatherSnapshot,
+} from '@/utils/weather';
 
 interface CloudInstance {
   basePosition: [number, number, number];
@@ -47,8 +52,15 @@ interface CloudInstance {
   parts: Array<{ position: [number, number, number]; scale: number }>;
 }
 
-const CloudsComponent: React.FC<{ timeScale: number }> = ({ timeScale }) => {
+interface CloudsProps {
+  timeScale: number;
+  weather: WeatherSnapshot;
+}
+
+const CloudsComponent: React.FC<CloudsProps> = ({ timeScale, weather }) => {
   const cloudRefs = useRef<Array<THREE.Group | null>>([]);
+  const cloudIntensity = getCloudIntensity(weather);
+  const rainIntensity = getRainIntensity(weather);
   const sharedGeometry = useMemo(
     () => new THREE.SphereGeometry(CLOUD_SPHERE_RADIUS, CLOUD_SPHERE_WIDTH_SEGMENTS, CLOUD_SPHERE_HEIGHT_SEGMENTS),
     []
@@ -101,6 +113,11 @@ const CloudsComponent: React.FC<{ timeScale: number }> = ({ timeScale }) => {
     (state, accumulatedDelta) => {
       const frameScale = accumulatedDelta * 60; // 60fps換算で速度を維持
       const time = state.clock.getElapsedTime();
+      sharedMaterial.opacity = Math.min(
+        0.78,
+        CLOUD_OPACITY * (0.72 + cloudIntensity * 0.95 + rainIntensity * 0.28)
+      );
+      sharedMaterial.emissiveIntensity = CLOUD_EMISSIVE_INTENSITY * (0.8 + cloudIntensity * 0.35);
       cloudRefs.current.forEach((ref, index) => {
         if (!ref) return;
         const data = clouds[index];

--- a/src/components/FishManager.tsx
+++ b/src/components/FishManager.tsx
@@ -25,6 +25,11 @@ import {
   FISH_MODEL_SCALE,
   FISH_MODEL_ROTATION,
 } from "../constants/fish";
+import {
+  getCloudIntensity,
+  getRainIntensity,
+  type WeatherSnapshot,
+} from "@/utils/weather";
 
 /** 魚の種類 */
 type FishType = "normal" | "flatfish";
@@ -61,9 +66,17 @@ interface Fish {
  * 魚群の管理コンポーネント
  * 季節に応じた色と速度で複数の魚をアニメーション
  */
-const FishManager: React.FC = () => {
+interface FishManagerProps {
+  weather: WeatherSnapshot;
+}
+
+const FishManager: React.FC<FishManagerProps> = ({ weather }) => {
   const { season } = useSeason();
   const [fishList, setFishList] = useState<Fish[]>([]);
+  const rainIntensity = getRainIntensity(weather);
+  const cloudIntensity = getCloudIntensity(weather);
+  const weatherSpeedMultiplier = 1.08 - rainIntensity * 0.34 - cloudIntensity * 0.12;
+  const weatherDepthOffset = -(rainIntensity * 0.55 + cloudIntensity * 0.18);
 
   useEffect(() => {
     // 季節に基づいて魚を初期化する
@@ -178,8 +191,8 @@ const FishManager: React.FC = () => {
 
         // 移動中のみ位置を更新
         if (newIsMoving) {
-          newX = fish.x + Math.cos(fish.directionX) * fish.speed * delta * FISH_MOVEMENT.FRAME_MULTIPLIER;
-          newZ = fish.z + Math.sin(fish.directionX) * fish.speed * delta * FISH_MOVEMENT.FRAME_MULTIPLIER;
+          newX = fish.x + Math.cos(fish.directionX) * fish.speed * weatherSpeedMultiplier * delta * FISH_MOVEMENT.FRAME_MULTIPLIER;
+          newZ = fish.z + Math.sin(fish.directionX) * fish.speed * weatherSpeedMultiplier * delta * FISH_MOVEMENT.FRAME_MULTIPLIER;
 
           // 境界チェック
           if (newX < FISH_BOUNDARY.X_MIN || newX > FISH_BOUNDARY.X_MAX) {
@@ -209,14 +222,17 @@ const FishManager: React.FC = () => {
       }
 
       // 通常の魚：従来通りの動き
-      let newX = fish.x + Math.cos(fish.directionX) * fish.speed * delta * FISH_MOVEMENT.FRAME_MULTIPLIER;
-      let newY = fish.y + Math.sin(fish.directionY) * fish.speed * delta * FISH_MOVEMENT.FRAME_MULTIPLIER;
+      let newX = fish.x + Math.cos(fish.directionX) * fish.speed * weatherSpeedMultiplier * delta * FISH_MOVEMENT.FRAME_MULTIPLIER;
+      let newY = fish.y + Math.sin(fish.directionY) * fish.speed * weatherSpeedMultiplier * delta * FISH_MOVEMENT.FRAME_MULTIPLIER;
       let newZ =
-        fish.z + Math.sin(fish.directionX) * fish.speed * FISH_MOVEMENT.Z_DRIFT_DAMPING * delta * FISH_MOVEMENT.FRAME_MULTIPLIER;
+        fish.z + Math.sin(fish.directionX) * fish.speed * weatherSpeedMultiplier * FISH_MOVEMENT.Z_DRIFT_DAMPING * delta * FISH_MOVEMENT.FRAME_MULTIPLIER;
       newZ = Math.max(FISH_BOUNDARY.Z_MIN, Math.min(FISH_BOUNDARY.Z_MAX, newZ));
 
       // 通常の魚：泳ぐ動きを模倣するためにわずかな垂直振動を追加する
-      newY += Math.sin(timeRef.current * FISH_MOVEMENT.SWIM_OSCILLATION_SPEED + fish.id) * FISH_MOVEMENT.SWIM_OSCILLATION_AMPLITUDE;
+      newY +=
+        Math.sin(timeRef.current * FISH_MOVEMENT.SWIM_OSCILLATION_SPEED + fish.id) *
+          FISH_MOVEMENT.SWIM_OSCILLATION_AMPLITUDE +
+        weatherDepthOffset;
 
       // 境界チェック
       if (newX < FISH_BOUNDARY.X_MIN || newX > FISH_BOUNDARY.X_MAX) {

--- a/src/components/LightingController.tsx
+++ b/src/components/LightingController.tsx
@@ -9,6 +9,11 @@ import {
   SEASON_COLORS,
   DIRECTIONAL_SHADOW_MAP_SIZE,
 } from "../constants/lighting";
+import {
+  getCloudIntensity,
+  getRainIntensity,
+  type WeatherSnapshot,
+} from "@/utils/weather";
 
 /** ライティング制御のプロパティ */
 interface LightingControllerProps {
@@ -20,6 +25,8 @@ interface LightingControllerProps {
   pointLightRef: React.RefObject<THREE.PointLight>;
   /** スポットライトへの参照 */
   spotLightRef: React.RefObject<THREE.SpotLight>;
+  /** 現在の天気 */
+  weather: WeatherSnapshot;
 }
 
 /**
@@ -32,6 +39,7 @@ const LightingController: React.FC<LightingControllerProps> = ({
   ambientLightRef,
   pointLightRef,
   spotLightRef,
+  weather,
 }) => {
   const isDay = useDayPeriod();
   const { season } = useSeason();
@@ -63,6 +71,10 @@ const LightingController: React.FC<LightingControllerProps> = ({
 
       const targetColor = dayNightColors.directional;
       const targetAmbientColor = dayNightColors.ambient;
+      const cloudIntensity = getCloudIntensity(weather);
+      const rainIntensity = getRainIntensity(weather);
+      const weatherDimming = Math.max(0.52, 1 - cloudIntensity * 0.24 - rainIntensity * 0.32);
+      const ambientDimming = Math.max(0.65, 1 - cloudIntensity * 0.16 - rainIntensity * 0.18);
 
       let targetIntensity: number;
       if (season === "summer") {
@@ -73,9 +85,11 @@ const LightingController: React.FC<LightingControllerProps> = ({
         targetIntensity = isDay ? DAY_INTENSITY.directional.default : NIGHT_INTENSITY.directional.default;
       }
 
-      const targetAmbientIntensity = isDay ? DAY_INTENSITY.ambient : NIGHT_INTENSITY.ambient;
-      const targetPointIntensity = isDay ? DAY_INTENSITY.point : NIGHT_INTENSITY.point;
-      const targetSpotIntensity = isDay ? DAY_INTENSITY.spot : NIGHT_INTENSITY.spot;
+      targetIntensity *= weatherDimming;
+
+      const targetAmbientIntensity = (isDay ? DAY_INTENSITY.ambient : NIGHT_INTENSITY.ambient) * ambientDimming;
+      const targetPointIntensity = (isDay ? DAY_INTENSITY.point : NIGHT_INTENSITY.point) * (0.88 + weatherDimming * 0.12);
+      const targetSpotIntensity = (isDay ? DAY_INTENSITY.spot : NIGHT_INTENSITY.spot) * (0.82 + weatherDimming * 0.18);
 
       // スムーズな切り替え
       directionalLightRef.current.intensity +=

--- a/src/components/RainEffect.tsx
+++ b/src/components/RainEffect.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useMemo } from 'react';
+import React, { useEffect, useRef, useMemo } from 'react';
 import * as THREE from 'three';
 import { useFrame } from '@react-three/fiber';
 import {
@@ -32,9 +32,33 @@ const spawnRainDrop = (): RainDrop => ({
   ] as [number, number],
 });
 
-const RainEffect: React.FC = () => {
+interface RainEffectProps {
+  intensity?: number;
+}
+
+const RainEffect: React.FC<RainEffectProps> = ({ intensity = 1 }) => {
   const meshRef = useRef<THREE.InstancedMesh>(null);
   const dummy = useMemo(() => new THREE.Object3D(), []);
+  const material = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        color: RAIN_COLOR,
+        transparent: true,
+        opacity: RAIN_OPACITY,
+      }),
+    []
+  );
+  const activeDropCount = useMemo(
+    () => Math.max(80, Math.min(RAIN_DROP_COUNT, Math.round(RAIN_DROP_COUNT * (0.35 + intensity * 0.75)))),
+    [intensity]
+  );
+  const speedMultiplier = 0.82 + intensity * 0.46;
+
+  useEffect(() => {
+    return () => {
+      material.dispose();
+    };
+  }, [material]);
 
   // 雨粒の初期データを生成（一度だけ）
   const rainDrops = useMemo<RainDrop[]>(() => {
@@ -44,11 +68,14 @@ const RainEffect: React.FC = () => {
   // アニメーション
   useFrame((_, delta) => {
     if (!meshRef.current) return;
+    meshRef.current.count = activeDropCount;
+    material.opacity = RAIN_OPACITY * (0.62 + intensity * 0.7);
 
-    rainDrops.forEach((drop, i) => {
+    for (let i = 0; i < activeDropCount; i += 1) {
+      const drop = rainDrops[i];
       // 落下処理
-      drop.position[1] += drop.velocity[1] * delta;
-      drop.position[0] += drop.velocity[0] * delta;
+      drop.position[1] += drop.velocity[1] * delta * speedMultiplier;
+      drop.position[0] += drop.velocity[0] * delta * (0.85 + intensity * 0.4);
 
       // 地面に到達したらリセット
       if (drop.position[1] < RAIN_RESET_Y) {
@@ -64,7 +91,7 @@ const RainEffect: React.FC = () => {
       if (meshRef.current) {
         meshRef.current.setMatrixAt(i, dummy.matrix);
       }
-    });
+    }
 
     if (meshRef.current) {
       meshRef.current.instanceMatrix.needsUpdate = true;
@@ -74,7 +101,7 @@ const RainEffect: React.FC = () => {
   return (
     <instancedMesh ref={meshRef} args={[undefined, undefined, RAIN_DROP_COUNT]}>
       <cylinderGeometry args={[RAIN_DROP_SIZE.WIDTH, RAIN_DROP_SIZE.WIDTH, RAIN_DROP_SIZE.HEIGHT, 4]} />
-      <meshBasicMaterial color={RAIN_COLOR} transparent opacity={RAIN_OPACITY} />
+      <primitive object={material} attach="material" />
     </instancedMesh>
   );
 };

--- a/src/components/SeasonalEffects.tsx
+++ b/src/components/SeasonalEffects.tsx
@@ -6,7 +6,7 @@ import FallenLeaves from './FallenLeaves';
 import SnowEffect from './SnowEffect';
 import RainEffect from './RainEffect';
 import { Fireflies } from './Fireflies';
-import { shouldShowRain, type WeatherSnapshot } from '@/utils/weather';
+import { getRainIntensity, shouldShowRain, type WeatherSnapshot } from '@/utils/weather';
 
 interface SeasonalEffectsProps {
   weather: WeatherSnapshot;
@@ -19,6 +19,7 @@ export const SeasonalEffects: React.FC<SeasonalEffectsProps> = ({ weather }) => 
   const { season } = useSeason();
   const isDay = useDayPeriod();
   const showRain = shouldShowRain(weather);
+  const rainIntensity = getRainIntensity(weather);
 
   return (
     <>
@@ -27,7 +28,7 @@ export const SeasonalEffects: React.FC<SeasonalEffectsProps> = ({ weather }) => 
       {season === 'summer' && !isDay && <Fireflies />}
       {(season === 'autumn' || season === 'winter') && <FallenLeaves />}
       {season === 'winter' && <SnowEffect />}
-      {showRain && <RainEffect />}
+      {showRain && <RainEffect intensity={rainIntensity} />}
     </>
   );
 };

--- a/src/components/WaterSurface.tsx
+++ b/src/components/WaterSurface.tsx
@@ -4,6 +4,12 @@ import type { ThreeEvent } from "@react-three/fiber";
 import { useSeason } from "../contexts";
 import { useThrottledFrame } from "../hooks/useThrottledFrame";
 import {
+  getRainIntensity,
+  getWaterReflectionIntensity,
+  getWeatherWaterTurbulence,
+  type WeatherSnapshot,
+} from "@/utils/weather";
+import {
   WATER_SURFACE_Y,
   WATER_SURFACE_Y_AMPLITUDE,
   WATER_SURFACE_Y_FREQUENCY,
@@ -81,9 +87,10 @@ const RIPPLE_SPARKLE_INDICES = [0, 1, 2, 3, 4] as const;
  */
 interface WaterSurfaceProps {
   onInteract?: () => void;
+  weather: WeatherSnapshot;
 }
 
-const WaterSurface: React.FC<WaterSurfaceProps> = ({ onInteract }) => {
+const WaterSurface: React.FC<WaterSurfaceProps> = ({ onInteract, weather }) => {
   const { season } = useSeason();
   const meshRef = useRef<THREE.Mesh>(null!);
   const geometryRef = useRef<THREE.PlaneGeometry>(null!);
@@ -92,7 +99,11 @@ const WaterSurface: React.FC<WaterSurfaceProps> = ({ onInteract }) => {
   const elapsedTimeRef = useRef(0);
   const nextRippleIdRef = useRef(0);
   const nextDropletIdRef = useRef(0);
+  const nextWeatherRippleAtRef = useRef(0);
   const [, setRenderTick] = useState(0);
+  const rainIntensity = getRainIntensity(weather);
+  const reflectionIntensity = getWaterReflectionIntensity(weather);
+  const waterTurbulence = getWeatherWaterTurbulence(weather);
 
   // マテリアルをメモ化してパフォーマンス向上
   const material = useMemo(
@@ -199,7 +210,8 @@ const WaterSurface: React.FC<WaterSurfaceProps> = ({ onInteract }) => {
   const addRipple = useCallback((
     rippleX: number,
     rippleY: number,
-    worldPoint: THREE.Vector3
+    worldPoint: THREE.Vector3,
+    notifyInteraction = true
   ) => {
     const ripplePoint = {
       id: nextRippleIdRef.current++,
@@ -234,7 +246,9 @@ const WaterSurface: React.FC<WaterSurfaceProps> = ({ onInteract }) => {
 
     dropletsRef.current = [...dropletsRef.current, ...dropletParticles].slice(-24);
     setRenderTick((tick) => tick + 1);
-    onInteract?.();
+    if (notifyInteraction) {
+      onInteract?.();
+    }
   }, [
     onInteract,
     rippleTuning.dropletCount,
@@ -263,6 +277,31 @@ const WaterSurface: React.FC<WaterSurfaceProps> = ({ onInteract }) => {
 
     const time = state.clock.getElapsedTime();
     elapsedTimeRef.current = time;
+    material.roughness = THREE.MathUtils.clamp(
+      WATER_ROUGHNESS + (1 - reflectionIntensity) * 0.52,
+      0.08,
+      0.72
+    );
+    material.envMapIntensity = WATER_ENV_MAP_INTENSITY * (0.55 + reflectionIntensity * 0.55);
+    material.opacity = THREE.MathUtils.clamp(
+      WATER_OPACITY + rainIntensity * 0.08,
+      0.22,
+      0.42
+    );
+
+    if (rainIntensity > 0.05 && time >= nextWeatherRippleAtRef.current) {
+      const seed = nextRippleIdRef.current * 31 + Math.floor(time * 7);
+      const rippleX = (pseudoRandom(seed) - 0.5) * 30;
+      const rippleY = (pseudoRandom(seed + 1) - 0.5) * 30;
+      addRipple(
+        rippleX,
+        rippleY,
+        new THREE.Vector3(rippleX, WATER_SURFACE_Y + 0.04, rippleY),
+        false
+      );
+      nextWeatherRippleAtRef.current = time + Math.max(0.18, 1.05 - rainIntensity * 0.72);
+    }
+
     const nextRipples = ripplesRef.current.filter(
       (ripple) => time - ripple.startTime < WATER_RIPPLE_LIFETIME
     );
@@ -281,7 +320,7 @@ const WaterSurface: React.FC<WaterSurfaceProps> = ({ onInteract }) => {
     const width = WATER_SURFACE_SCALE_X;
     const height = WATER_SURFACE_SCALE_Y;
     const segments = WATER_SURFACE_SEGMENTS;
-    const timeScale = time * WATER_WAVE_TIME_SCALE;
+    const timeScale = time * WATER_WAVE_TIME_SCALE * (0.92 + waterTurbulence * 0.08);
 
     for (let i = 0; i <= segments; i++) {
       const x = (i / segments - 0.5) * width;
@@ -307,7 +346,10 @@ const WaterSurface: React.FC<WaterSurfaceProps> = ({ onInteract }) => {
         }
 
         positions[index] =
-          sinX * Math.cos(y * WATER_WAVE_FREQUENCY + timeScale) * WATER_WAVE_AMPLITUDE +
+          sinX *
+            Math.cos(y * WATER_WAVE_FREQUENCY + timeScale) *
+            WATER_WAVE_AMPLITUDE *
+            waterTurbulence +
           rippleOffset;
       }
     }

--- a/src/components/WindDirectionDisplay.tsx
+++ b/src/components/WindDirectionDisplay.tsx
@@ -19,6 +19,24 @@ const windDirectionMap = {
   West: { rotation: 270, label: '西', kanji: '西' },
 };
 
+const formatForecastHour = (date: Date) =>
+  `${String(date.getHours()).padStart(2, '0')}時`;
+
+const getWeatherTone = (condition: WeatherSnapshot['condition']) => {
+  switch (condition) {
+    case 'rain':
+      return '雨粒';
+    case 'cloudy':
+      return 'やわらぐ光';
+    case 'clear':
+    default:
+      return '戻る光';
+  }
+};
+
+const formatWindSpeed = (speed: number | null) =>
+  speed === null ? null : `${speed.toFixed(1)}m/s`;
+
 /**
  * 風向きコンパス表示コンポーネント
  * 現在の風向きを視覚的に表示
@@ -30,6 +48,8 @@ const WindDirectionDisplay: React.FC<WindDirectionDisplayProps> = ({
 }) => {
   const { rotation, kanji } = windDirectionMap[windDirection];
   const isMobile = useIsMobile();
+  const forecastPreview = weather.forecast.slice(1, 4);
+  const windSpeedText = formatWindSpeed(weather.windSpeed);
 
   return (
     <div
@@ -266,6 +286,89 @@ const WindDirectionDisplay: React.FC<WindDirectionDisplayProps> = ({
             ? `${weather.location}の実天気`
             : '水辺の天気'}
         </div>
+        {windSpeedText && (
+          <div
+            style={{
+              marginTop: '3px',
+              fontSize: '10px',
+              color: 'rgba(255, 255, 255, 0.58)',
+              lineHeight: 1.4,
+            }}
+          >
+            風 {windSpeedText}
+          </div>
+        )}
+        {forecastPreview.length > 0 && (
+          <div
+            style={{
+              width: '100%',
+              marginTop: tokens.spacing.sm,
+              paddingTop: tokens.spacing.sm,
+              borderTop: '1px solid rgba(255, 255, 255, 0.12)',
+            }}
+          >
+            <div
+              style={{
+                marginBottom: '6px',
+                fontSize: '10px',
+                letterSpacing: '0.08em',
+                color: 'rgba(255, 255, 255, 0.58)',
+              }}
+            >
+              水辺予報
+            </div>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                gap: '6px',
+              }}
+            >
+              {forecastPreview.map((point) => (
+                <div
+                  key={point.time.toISOString()}
+                  style={{
+                    minWidth: '34px',
+                    padding: '5px 6px',
+                    borderRadius: '8px',
+                    border: '1px solid rgba(255, 255, 255, 0.12)',
+                    background: 'rgba(255, 255, 255, 0.07)',
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: '9px',
+                      color: 'rgba(255, 255, 255, 0.5)',
+                      lineHeight: 1.2,
+                    }}
+                  >
+                    {formatForecastHour(point.time)}
+                  </div>
+                  <div
+                    style={{
+                      marginTop: '2px',
+                      fontSize: '13px',
+                      color: 'rgba(255, 255, 255, 0.9)',
+                      lineHeight: 1.2,
+                    }}
+                  >
+                    {point.label}
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div
+              style={{
+                marginTop: '6px',
+                fontSize: '10px',
+                color: 'rgba(255, 255, 255, 0.68)',
+                lineHeight: 1.45,
+              }}
+            >
+              {weather.forecastSummary || getWeatherTone(forecastPreview[0].condition)}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/utils/bottleJournal.ts
+++ b/src/utils/bottleJournal.ts
@@ -158,8 +158,9 @@ export const createDailyLifeLog = ({
   const weatherSourceText =
     weather.source === "open-meteo" ? `${weather.location}の${weather.label}。` : "";
   const windText = `${windLabels[windDirection]}からの風。`;
+  const forecastText = weather.forecastSummary ? `${weather.forecastSummary}。` : "";
 
-  return `${formatJournalDate(date)}、${seasonLabels[season]}の${timeLabels[timeOfDay]}。${weatherSourceText}${seasonalText}。${weatherText}。${timeText}。${windText}`;
+  return `${formatJournalDate(date)}、${seasonLabels[season]}の${timeLabels[timeOfDay]}。${weatherSourceText}${seasonalText}。${weatherText}。${forecastText}${timeText}。${windText}`;
 };
 
 export const loadBottleJournal = (): BottleJournalEntry[] => {

--- a/src/utils/weather.ts
+++ b/src/utils/weather.ts
@@ -10,6 +10,18 @@ import {
 
 export type WeatherCondition = "clear" | "cloudy" | "rain";
 
+export interface WeatherForecastPoint {
+  time: Date;
+  condition: WeatherCondition;
+  label: string;
+  description: string;
+  precipitation: number;
+  precipitationProbability: number | null;
+  cloudCover: number;
+  windDirection: number;
+  windSpeed: number;
+}
+
 export interface WeatherSnapshot {
   condition: WeatherCondition;
   label: string;
@@ -17,6 +29,12 @@ export interface WeatherSnapshot {
   observedAt: Date;
   source: "open-meteo" | "fallback";
   location: string;
+  precipitation: number;
+  cloudCover: number;
+  windDirection: number | null;
+  windSpeed: number | null;
+  forecast: WeatherForecastPoint[];
+  forecastSummary: string;
 }
 
 interface WeatherApiResponse {
@@ -26,6 +44,21 @@ interface WeatherApiResponse {
   observedAt: string;
   source: "open-meteo";
   location: string;
+  precipitation: number;
+  cloudCover: number;
+  windDirection: number;
+  windSpeed: number;
+  forecast?: Array<{
+    time: string;
+    condition: WeatherCondition;
+    label: string;
+    description: string;
+    precipitation: number;
+    precipitationProbability: number | null;
+    cloudCover: number;
+    windDirection: number;
+    windSpeed: number;
+  }>;
 }
 
 const weatherLabels: Record<WeatherCondition, string> = {
@@ -38,6 +71,18 @@ const weatherDescriptions: Record<WeatherCondition, string> = {
   clear: "水面がよく光る",
   cloudy: "光がやわらぐ",
   rain: "雨粒が落ちる",
+};
+
+const fallbackPrecipitation: Record<WeatherCondition, number> = {
+  clear: 0,
+  cloudy: 0,
+  rain: 1.2,
+};
+
+const fallbackCloudCover: Record<WeatherCondition, number> = {
+  clear: 18,
+  cloudy: 68,
+  rain: 92,
 };
 
 const getJapanDate = (date: Date) =>
@@ -58,7 +103,7 @@ const getWeatherScore = (date: Date) => {
   };
 };
 
-export const getFallbackWeather = (date = new Date()): WeatherSnapshot => {
+const getFallbackCondition = (date: Date): WeatherCondition => {
   const { month, score } = getWeatherScore(date);
   const rainThreshold =
     month === RAINY_SEASON_MONTH
@@ -69,12 +114,47 @@ export const getFallbackWeather = (date = new Date()): WeatherSnapshot => {
       ? RAINY_SEASON_CLOUDY_THRESHOLD
       : DEFAULT_CLOUDY_THRESHOLD;
 
-  const condition: WeatherCondition =
-    score < rainThreshold
-      ? "rain"
-      : score < cloudyThreshold
-        ? "cloudy"
-        : "clear";
+  return score < rainThreshold
+    ? "rain"
+    : score < cloudyThreshold
+      ? "cloudy"
+      : "clear";
+};
+
+const createForecastSummary = (forecast: WeatherForecastPoint[]) => {
+  const upcoming = forecast.slice(1, 4);
+  if (upcoming.some((point) => point.condition === "rain")) {
+    return "このあと雨粒が近づく";
+  }
+
+  if (upcoming.some((point) => point.condition === "clear")) {
+    return "このあと光が戻る";
+  }
+
+  return "しばらく光はやわらかい";
+};
+
+const createFallbackForecast = (date: Date): WeatherForecastPoint[] =>
+  Array.from({ length: 6 }, (_, index) => {
+    const forecastDate = new Date(date.getTime() + index * 60 * 60 * 1000);
+    const condition = getFallbackCondition(forecastDate);
+
+    return {
+      time: getJapanDate(forecastDate),
+      condition,
+      label: weatherLabels[condition],
+      description: weatherDescriptions[condition],
+      precipitation: fallbackPrecipitation[condition],
+      precipitationProbability: condition === "rain" ? 72 : condition === "cloudy" ? 28 : 8,
+      cloudCover: fallbackCloudCover[condition],
+      windDirection: (forecastDate.getHours() * 35 + index * 23) % 360,
+      windSpeed: condition === "rain" ? 4.8 : condition === "cloudy" ? 3.1 : 2.2,
+    };
+  });
+
+export const getFallbackWeather = (date = new Date()): WeatherSnapshot => {
+  const condition = getFallbackCondition(date);
+  const forecast = createFallbackForecast(date);
 
   return {
     condition,
@@ -83,6 +163,12 @@ export const getFallbackWeather = (date = new Date()): WeatherSnapshot => {
     observedAt: getJapanDate(date),
     source: "fallback",
     location: "水辺",
+    precipitation: fallbackPrecipitation[condition],
+    cloudCover: fallbackCloudCover[condition],
+    windDirection: null,
+    windSpeed: null,
+    forecast,
+    forecastSummary: createForecastSummary(forecast),
   };
 };
 
@@ -99,6 +185,11 @@ export const fetchWeather = async (): Promise<WeatherSnapshot | null> => {
     }
 
     const data: WeatherApiResponse = await response.json();
+    const forecast = (data.forecast ?? []).map((point) => ({
+      ...point,
+      time: new Date(point.time),
+    }));
+
     return {
       condition: data.condition,
       label: data.label,
@@ -106,6 +197,12 @@ export const fetchWeather = async (): Promise<WeatherSnapshot | null> => {
       observedAt: new Date(data.observedAt),
       source: data.source,
       location: data.location,
+      precipitation: data.precipitation,
+      cloudCover: data.cloudCover,
+      windDirection: data.windDirection,
+      windSpeed: data.windSpeed,
+      forecast,
+      forecastSummary: createForecastSummary(forecast),
     };
   } catch (error) {
     console.error("Error fetching weather:", error);
@@ -115,3 +212,24 @@ export const fetchWeather = async (): Promise<WeatherSnapshot | null> => {
 
 export const shouldShowRain = (weather: WeatherSnapshot) =>
   weather.condition === "rain";
+
+export const getRainIntensity = (weather: WeatherSnapshot) => {
+  const current = Math.min(1, weather.precipitation / 4);
+  const nearFuture = Math.max(
+    0,
+    ...weather.forecast.slice(0, 3).map((point) => Math.min(1, point.precipitation / 4))
+  );
+  return Math.max(current, nearFuture * 0.45);
+};
+
+export const getCloudIntensity = (weather: WeatherSnapshot) =>
+  Math.max(0, Math.min(1, weather.cloudCover / 100));
+
+export const getWaterReflectionIntensity = (weather: WeatherSnapshot) => {
+  const cloudDimming = getCloudIntensity(weather) * 0.45;
+  const rainDimming = getRainIntensity(weather) * 0.35;
+  return Math.max(0.25, 1 - cloudDimming - rainDimming);
+};
+
+export const getWeatherWaterTurbulence = (weather: WeatherSnapshot) =>
+  1 + getRainIntensity(weather) * 0.65 + getCloudIntensity(weather) * 0.12;

--- a/tmp/029_weather-location-source/plan.md
+++ b/tmp/029_weather-location-source/plan.md
@@ -1,0 +1,41 @@
+# 実装計画: weather-location-source
+
+## 背景
+天気APIが東京駅固定になっていて、「水辺の四季」の体験に対して現実の東京が唐突に出ていた。
+
+## 目的
+東京固定をやめ、本番では Cloudflare のリクエスト位置情報を使い、位置情報が取れない環境では既存の「水辺の天気」フォールバックに任せる。
+さらに、天気を単なる `晴/曇/雨` 表示ではなく、水辺の光・雨・波・魚・便りに影響する状態モデルとして扱う。
+
+## 変更
+- `functions/api/weather.ts`
+  - 東京駅の固定座標を削除
+  - `request.cf.latitude` / `request.cf.longitude` を使って Open-Meteo を呼び出す
+  - 表示地点名は `city`、`region`、`country`、`現在地` の順で決定
+  - 位置情報がない場合は `204 No Content` を返し、フロントの fallback に落とす
+  - 東京前提の説明文を「近くの空/光/雨」に変更
+- `src/utils/weather.ts`
+  - current に加えて直近 hourly forecast を保持する。
+  - 降水量、雲量、風速、風向き、水辺予報の summary を扱う。
+  - 雨の強さ、雲量、水面反射、水面の荒れ方を導出する helper を追加する。
+- `src/components/RainEffect.tsx`
+  - 雨量に応じて雨粒数、速度、透明度を変える。
+- `src/components/WaterSurface.tsx`
+  - 雨量で自動波紋を発生させる。
+  - 雲量/雨量で水面反射と波の荒れ方を変える。
+- `src/components/FishManager.tsx`
+  - 雨/曇りでは魚が少し深く、ゆっくり泳ぐ。
+- `src/components/Clouds.tsx`
+  - 雲量/雨量で雲の濃さを変える。
+- `src/components/LightingController.tsx`
+  - 雲量/雨量で光量を落とす。
+- `src/components/WindDirectionDisplay.tsx`
+  - 今の天気だけでなく、次の数時間の「水辺予報」と風速を表示する。
+- `src/utils/bottleJournal.ts`
+  - 便りの観察ログに今後の天気の気配を混ぜる。
+
+## 検証
+- [x] `npx tsc --noEmit`
+- [x] `npm run lint`
+- [x] `npm run build`
+- [x] Playwright + Google Chrome で実画面確認

--- a/tmp/029_weather-location-source/prompt.md
+++ b/tmp/029_weather-location-source/prompt.md
@@ -1,0 +1,26 @@
+# 実装セッション: weather-location-source
+
+## セッション情報
+- 開始日時: 2026-06-25
+- タスク: 天気APIの東京固定をやめる
+
+## 完了
+- [x] 東京駅固定の座標を削除
+- [x] Cloudflare request.cf の緯度経度を Open-Meteo に渡す
+- [x] 位置情報がない時は 204 を返して fallback に任せる
+- [x] 東京前提の天気説明文を削除
+- [x] Open-Meteo の hourly forecast を API レスポンスに追加
+- [x] フロントの `WeatherSnapshot` を current + forecast + 水辺状態 helper に拡張
+- [x] 雨量で `RainEffect` の密度/速度/透明度を変更
+- [x] 雨量/雲量で水面の波、反射、自動波紋を変更
+- [x] 雨/曇りで魚の泳ぐ深さと速度を変更
+- [x] 雲量/雨量で雲と光量を変更
+- [x] 実風向きが取れる場合は風向き表示に反映
+- [x] 水辺予報と風速を UI に追加
+- [x] 便りの観察ログに今後の天気の気配を追加
+
+## 検証
+- [x] `npx tsc --noEmit`
+- [x] `npm run lint`
+- [x] `npm run build`
+- [x] Playwright + Google Chrome で実画面確認


### PR DESCRIPTION
## Summary
- 天気APIの東京駅固定座標を削除し、Cloudflare request.cf の緯度経度で Open-Meteo を取得
- 位置情報が取れない環境では 204 を返し、既存の水辺フォールバック天気に落とす
- Open-Meteo の current に加えて直近 hourly forecast、降水量、雲量、風速、風向きを WeatherSnapshot に保持
- 雨量で RainEffect の密度/速度/透明度と水面の自動波紋を変化
- 雲量/雨量で水面反射、波の荒れ方、雲の濃さ、シーン光量を変化
- 雨/曇りで魚が少し深く、ゆっくり泳ぐよう調整
- 実風向きが取れる場合は風向き表示へ反映
- 風向きパネルに水辺予報と風速を追加
- 便りの観察ログに今後の天気の気配を追加

## Tests
- npx tsc --noEmit
- npm run lint
- npm run build
- Playwright + Google Chrome で実画面確認