### PR TITLE
feature: 天気ディレクターで水辺の演出を拡張

### DIFF
--- a/functions/api/weather.ts
+++ b/functions/api/weather.ts
@@ -8,39 +8,69 @@
 interface OpenMeteoCurrent {
   time: string;
   weather_code: number;
+  temperature_2m: number;
+  apparent_temperature: number;
+  relative_humidity_2m: number;
   precipitation: number;
   rain: number;
   showers: number;
   snowfall: number;
   cloud_cover: number;
+  visibility: number;
   wind_direction_10m: number;
   wind_speed_10m: number;
+  wind_gusts_10m: number;
+  shortwave_radiation: number;
+  is_day: number;
 }
 
 interface OpenMeteoHourly {
   time: string[];
   weather_code: number[];
+  temperature_2m: number[];
+  apparent_temperature: number[];
+  relative_humidity_2m: number[];
   precipitation_probability?: number[];
   precipitation: number[];
   rain: number[];
   showers: number[];
   snowfall: number[];
   cloud_cover: number[];
+  visibility: number[];
   wind_direction_10m: number[];
   wind_speed_10m: number[];
+  wind_gusts_10m: number[];
+  shortwave_radiation: number[];
+  is_day: number[];
+}
+
+interface OpenMeteoDaily {
+  sunrise: string[];
+  sunset: string[];
 }
 
 interface OpenMeteoResponse {
   current: OpenMeteoCurrent;
   hourly?: OpenMeteoHourly;
+  daily?: OpenMeteoDaily;
 }
 
-type WeatherCondition = "clear" | "cloudy" | "rain";
+type WeatherCondition =
+  | "clear"
+  | "partly-cloudy"
+  | "cloudy"
+  | "fog"
+  | "drizzle"
+  | "rain"
+  | "showers"
+  | "snow"
+  | "thunderstorm";
 
 interface RequestLocation {
   name: string;
   latitude: number;
   longitude: number;
+  source: "browser" | "cloudflare";
 }
 
 interface CloudflareGeo {
@@ -56,56 +86,41 @@ const FORECAST_HOURS = 6;
 
 const WEATHER_LABELS: Record<WeatherCondition, string> = {
   clear: "晴",
+  "partly-cloudy": "薄曇",
   cloudy: "曇",
+  fog: "霧",
+  drizzle: "霧雨",
   rain: "雨",
+  showers: "にわか雨",
+  snow: "雪",
+  thunderstorm: "雷雨",
 };
 
 const WEATHER_DESCRIPTIONS: Record<WeatherCondition, string> = {
   clear: "近くの空が明るい",
+  "partly-cloudy": "雲間から光が差す",
   cloudy: "近くの光がやわらぐ",
+  fog: "水辺に霧が漂う",
+  drizzle: "細かな雨が水面を撫でる",
   rain: "近くに雨が降る",
+  showers: "雨脚が近づいては離れる",
+  snow: "白い粒が静かに落ちる",
+  thunderstorm: "遠くで空が鳴る",
 };
 
-const rainyWeatherCodes = new Set([
-  51, 53, 55, 56, 57, 61, 63, 65, 66, 67, 71, 73, 75, 77, 80, 81, 82, 85, 86,
-  95, 96, 99,
-]);
-
-const cloudyWeatherCodes = new Set([2, 3, 45, 48]);
-
-const getCondition = (current: OpenMeteoCurrent): WeatherCondition => {
-  const precipitation =
-    current.precipitation + current.rain + current.showers + current.snowfall;
-
-  if (precipitation > 0 || rainyWeatherCodes.has(current.weather_code)) {
-    return "rain";
+const getCondition = (weatherCode: number, cloudCover: number): WeatherCondition => {
+  if (weatherCode === 0) return "clear";
+  if (weatherCode === 1) return "partly-cloudy";
+  if (weatherCode === 2 || weatherCode === 3) return "cloudy";
+  if (weatherCode === 45 || weatherCode === 48) return "fog";
+  if (weatherCode >= 51 && weatherCode <= 57) return "drizzle";
+  if (weatherCode >= 61 && weatherCode <= 67) return "rain";
+  if ((weatherCode >= 71 && weatherCode <= 77) || weatherCode === 85 || weatherCode === 86) {
+    return "snow";
   }
-
-  if (current.cloud_cover >= 55 || cloudyWeatherCodes.has(current.weather_code)) {
-    return "cloudy";
-  }
-
-  return "clear";
-};
-
-const getHourlyCondition = ({
-  weatherCode,
-  precipitation,
-  cloudCover,
-}: {
-  weatherCode: number;
-  precipitation: number;
-  cloudCover: number;
-}): WeatherCondition => {
-  if (precipitation > 0 || rainyWeatherCodes.has(weatherCode)) {
-    return "rain";
-  }
-
-  if (cloudCover >= 55 || cloudyWeatherCodes.has(weatherCode)) {
-    return "cloudy";
-  }
-
-  return "clear";
+  if (weatherCode >= 80 && weatherCode <= 82) return "showers";
+  if (weatherCode >= 95) return "thunderstorm";
+  return cloudCover >= 55 ? "cloudy" : "clear";
 };
 
 const sumPrecipitation = ({
@@ -118,7 +133,7 @@ const sumPrecipitation = ({
   rain: number;
   showers: number;
   snowfall: number;
-}) => precipitation + rain + showers + snowfall;
+}) => Math.max(precipitation, rain + showers + snowfall / 7);
 
 const getStringValue = (value: unknown) =>
   typeof value === "string" && value.trim() ? value.trim() : null;
@@ -137,6 +152,25 @@ const getNumberValue = (value: unknown) => {
 };
 
 const getRequestLocation = (request: Request): RequestLocation | null => {
+  const url = new URL(request.url);
+  const requestedLatitude = getNumberValue(url.searchParams.get("latitude"));
+  const requestedLongitude = getNumberValue(url.searchParams.get("longitude"));
+  if (
+    requestedLatitude !== null &&
+    requestedLongitude !== null &&
+    requestedLatitude >= -90 &&
+    requestedLatitude <= 90 &&
+    requestedLongitude >= -180 &&
+    requestedLongitude <= 180
+  ) {
+    return {
+      name: "現在地",
+      latitude: requestedLatitude,
+      longitude: requestedLongitude,
+      source: "browser",
+    };
+  }
+
   const cf = request.cf as CloudflareGeo | undefined;
   const latitude = getNumberValue(cf?.latitude);
   const longitude = getNumberValue(cf?.longitude);
@@ -154,6 +188,7 @@ const getRequestLocation = (request: Request): RequestLocation | null => {
     name,
     latitude,
     longitude,
+    source: "cloudflare",
   };
 };
 
@@ -187,29 +222,45 @@ export const onRequest = async (context: EventContext<unknown, string, Record<st
       "current",
       [
         "weather_code",
+        "temperature_2m",
+        "apparent_temperature",
+        "relative_humidity_2m",
         "precipitation",
         "rain",
         "showers",
         "snowfall",
         "cloud_cover",
+        "visibility",
         "wind_direction_10m",
         "wind_speed_10m",
+        "wind_gusts_10m",
+        "shortwave_radiation",
+        "is_day",
       ].join(",")
     );
     apiUrl.searchParams.set(
       "hourly",
       [
         "weather_code",
+        "temperature_2m",
+        "apparent_temperature",
+        "relative_humidity_2m",
         "precipitation_probability",
         "precipitation",
         "rain",
         "showers",
         "snowfall",
         "cloud_cover",
+        "visibility",
         "wind_direction_10m",
         "wind_speed_10m",
+        "wind_gusts_10m",
+        "shortwave_radiation",
+        "is_day",
       ].join(",")
     );
+    apiUrl.searchParams.set("daily", "sunrise,sunset");
+    apiUrl.searchParams.set("wind_speed_unit", "ms");
     apiUrl.searchParams.set("timezone", "auto");
     apiUrl.searchParams.set("forecast_days", "1");
     apiUrl.searchParams.set("forecast_hours", String(FORECAST_HOURS));
@@ -230,7 +281,7 @@ export const onRequest = async (context: EventContext<unknown, string, Record<st
 
     const data: OpenMeteoResponse = await response.json();
     const current = data.current;
-    const condition = getCondition(current);
+    const condition = getCondition(current.weather_code, current.cloud_cover);
     const currentPrecipitation = sumPrecipitation({
       precipitation: current.precipitation,
       rain: current.rain,
@@ -246,22 +297,30 @@ export const onRequest = async (context: EventContext<unknown, string, Record<st
         snowfall: hourly.snowfall[index] ?? 0,
       });
       const cloudCover = hourly.cloud_cover[index] ?? 0;
-      const hourlyCondition = getHourlyCondition({
-        weatherCode: hourly.weather_code[index] ?? 0,
-        precipitation,
-        cloudCover,
-      });
+      const rain = (hourly.rain[index] ?? 0) + (hourly.showers[index] ?? 0);
+      const snowfall = hourly.snowfall[index] ?? 0;
+      const hourlyCondition = getCondition(hourly.weather_code[index] ?? 0, cloudCover);
 
       return {
         time,
         condition: hourlyCondition,
         label: WEATHER_LABELS[hourlyCondition],
         description: WEATHER_DESCRIPTIONS[hourlyCondition],
+        weatherCode: hourly.weather_code[index] ?? 0,
+        temperature: hourly.temperature_2m[index] ?? 0,
+        apparentTemperature: hourly.apparent_temperature[index] ?? 0,
+        humidity: hourly.relative_humidity_2m[index] ?? 0,
         precipitation,
+        rain,
+        snowfall,
         precipitationProbability: hourly.precipitation_probability?.[index] ?? null,
         cloudCover,
+        visibility: hourly.visibility[index] ?? 20_000,
         windDirection: hourly.wind_direction_10m[index] ?? 0,
         windSpeed: hourly.wind_speed_10m[index] ?? 0,
+        windGusts: hourly.wind_gusts_10m[index] ?? 0,
+        solarRadiation: hourly.shortwave_radiation[index] ?? 0,
+        isDay: (hourly.is_day[index] ?? 0) === 1,
       };
     }) ?? [];
 
@@ -273,11 +332,23 @@ export const onRequest = async (context: EventContext<unknown, string, Record<st
         observedAt: current.time,
         source: "open-meteo",
         location: location.name,
+        locationSource: location.source,
         weatherCode: current.weather_code,
+        temperature: current.temperature_2m,
+        apparentTemperature: current.apparent_temperature,
+        humidity: current.relative_humidity_2m,
         cloudCover: current.cloud_cover,
+        visibility: current.visibility,
         precipitation: currentPrecipitation,
+        rain: current.rain + current.showers,
+        snowfall: current.snowfall,
         windDirection: current.wind_direction_10m,
         windSpeed: current.wind_speed_10m,
+        windGusts: current.wind_gusts_10m,
+        solarRadiation: current.shortwave_radiation,
+        isDay: current.is_day === 1,
+        sunrise: data.daily?.sunrise[0] ?? null,
+        sunset: data.daily?.sunset[0] ?? null,
         forecast,
         cacheTtl: CACHE_TTL_SECONDS,
       }),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import FishManager from "./components/FishManager";
 import ParticleLayerInstanced from "./components/ParticleLayerInstanced";
 import Clouds from "./components/Clouds";
 import WindDirectionDisplay from "./components/WindDirectionDisplay";
+import WeatherAtmosphere from "./components/WeatherAtmosphere";
 import Ground from "./components/Ground";
 import Stars from "./components/Stars";
 import ShootingStars from "./components/ShootingStars";
@@ -110,7 +111,7 @@ type AppStyle = React.CSSProperties & { "--app-background-color"?: string };
 const AppContent = () => {
   const isDay = useDayPeriod();
   const simulatedWindDirection = useWindDirection();
-  const weather = useWeather();
+  const { weather, locationStatus, requestPreciseLocation } = useWeather();
   const windDirection = useMemo(
     () => getWindDirectionFromDegrees(weather.windDirection, simulatedWindDirection),
     [simulatedWindDirection, weather.windDirection]
@@ -218,7 +219,11 @@ const AppContent = () => {
 
           {/* シーンの背景と霧 */}
           <color attach="background" args={[backgroundColor]} />
-          <fog attach="fog" args={[backgroundColor, 10, isDay ? 60 : 40]} />
+          <WeatherAtmosphere
+            backgroundColor={backgroundColor}
+            isDay={isDay}
+            weather={weather}
+          />
 
           {/* ライティング */}
           <SceneLights
@@ -311,6 +316,8 @@ const AppContent = () => {
           <MemoizedWindDirectionDisplay
             windDirection={windDirection}
             weather={weather}
+            locationStatus={locationStatus}
+            onRequestPreciseLocation={requestPreciseLocation}
           />
         )}
       </div>

--- a/src/components/Clouds.tsx
+++ b/src/components/Clouds.tsx
@@ -39,6 +39,7 @@ import {
 } from '../constants/clouds';
 import {
   getCloudIntensity,
+  getGustIntensity,
   getRainIntensity,
   type WeatherSnapshot,
 } from '@/utils/weather';
@@ -61,6 +62,7 @@ const CloudsComponent: React.FC<CloudsProps> = ({ timeScale, weather }) => {
   const cloudRefs = useRef<Array<THREE.Group | null>>([]);
   const cloudIntensity = getCloudIntensity(weather);
   const rainIntensity = getRainIntensity(weather);
+  const gustIntensity = getGustIntensity(weather);
   const sharedGeometry = useMemo(
     () => new THREE.SphereGeometry(CLOUD_SPHERE_RADIUS, CLOUD_SPHERE_WIDTH_SEGMENTS, CLOUD_SPHERE_HEIGHT_SEGMENTS),
     []
@@ -121,7 +123,7 @@ const CloudsComponent: React.FC<CloudsProps> = ({ timeScale, weather }) => {
       cloudRefs.current.forEach((ref, index) => {
         if (!ref) return;
         const data = clouds[index];
-        const xIncrement = data.speed * CLOUD_MOVEMENT_SPEED * timeScale * frameScale;
+        const xIncrement = data.speed * CLOUD_MOVEMENT_SPEED * timeScale * frameScale * (1 + gustIntensity * 2.2);
         ref.position.x += xIncrement;
         ref.position.y =
           data.basePosition[1] +

--- a/src/components/FishManager.tsx
+++ b/src/components/FishManager.tsx
@@ -81,7 +81,8 @@ const FishManager: React.FC<FishManagerProps> = ({ weather }) => {
   const rainIntensity = getRainIntensity(weather);
   const cloudIntensity = getCloudIntensity(weather);
   const weatherSpeedMultiplier = 1.08 - rainIntensity * 0.34 - cloudIntensity * 0.12;
-  const weatherDepthOffset = -(rainIntensity * 0.55 + cloudIntensity * 0.18);
+  const temperatureDepthOffset = weather.temperature >= 27 ? -0.28 : weather.temperature <= 8 ? -0.16 : 0;
+  const weatherDepthOffset = -(rainIntensity * 0.55 + cloudIntensity * 0.18) + temperatureDepthOffset;
 
   useEffect(() => {
     // 季節に基づいて魚を初期化する

--- a/src/components/LightingController.tsx
+++ b/src/components/LightingController.tsx
@@ -11,7 +11,9 @@ import {
 } from "../constants/lighting";
 import {
   getCloudIntensity,
+  getFogIntensity,
   getRainIntensity,
+  getSolarIntensity,
   type WeatherSnapshot,
 } from "@/utils/weather";
 
@@ -73,8 +75,13 @@ const LightingController: React.FC<LightingControllerProps> = ({
       const targetAmbientColor = dayNightColors.ambient;
       const cloudIntensity = getCloudIntensity(weather);
       const rainIntensity = getRainIntensity(weather);
-      const weatherDimming = Math.max(0.52, 1 - cloudIntensity * 0.24 - rainIntensity * 0.32);
-      const ambientDimming = Math.max(0.65, 1 - cloudIntensity * 0.16 - rainIntensity * 0.18);
+      const fogIntensity = getFogIntensity(weather);
+      const solarIntensity = getSolarIntensity(weather);
+      const weatherDimming = Math.max(
+        0.42,
+        0.72 + solarIntensity * 0.38 - cloudIntensity * 0.22 - rainIntensity * 0.3 - fogIntensity * 0.2
+      );
+      const ambientDimming = Math.max(0.58, 1 - cloudIntensity * 0.14 - rainIntensity * 0.16 - fogIntensity * 0.18);
 
       let targetIntensity: number;
       if (season === "summer") {

--- a/src/components/RainEffect.tsx
+++ b/src/components/RainEffect.tsx
@@ -34,9 +34,10 @@ const spawnRainDrop = (): RainDrop => ({
 
 interface RainEffectProps {
   intensity?: number;
+  gustIntensity?: number;
 }
 
-const RainEffect: React.FC<RainEffectProps> = ({ intensity = 1 }) => {
+const RainEffect: React.FC<RainEffectProps> = ({ intensity = 1, gustIntensity = 0 }) => {
   const meshRef = useRef<THREE.InstancedMesh>(null);
   const dummy = useMemo(() => new THREE.Object3D(), []);
   const material = useMemo(
@@ -86,7 +87,7 @@ const RainEffect: React.FC<RainEffectProps> = ({ intensity = 1 }) => {
 
       // 行列を更新
       dummy.position.set(drop.position[0], drop.position[1], drop.position[2]);
-      dummy.rotation.z = RAIN_DROP_TILT;
+      dummy.rotation.z = RAIN_DROP_TILT - gustIntensity * 0.32;
       dummy.updateMatrix();
       if (meshRef.current) {
         meshRef.current.setMatrixAt(i, dummy.matrix);

--- a/src/components/SeasonalEffects.tsx
+++ b/src/components/SeasonalEffects.tsx
@@ -6,7 +6,14 @@ import FallenLeaves from './FallenLeaves';
 import SnowEffect from './SnowEffect';
 import RainEffect from './RainEffect';
 import { Fireflies } from './Fireflies';
-import { getRainIntensity, shouldShowRain, type WeatherSnapshot } from '@/utils/weather';
+import {
+  getRainIntensity,
+  getGustIntensity,
+  getSnowIntensity,
+  shouldShowRain,
+  shouldShowSnow,
+  type WeatherSnapshot,
+} from '@/utils/weather';
 
 interface SeasonalEffectsProps {
   weather: WeatherSnapshot;
@@ -19,7 +26,10 @@ export const SeasonalEffects: React.FC<SeasonalEffectsProps> = ({ weather }) => 
   const { season } = useSeason();
   const isDay = useDayPeriod();
   const showRain = shouldShowRain(weather);
+  const showSnow = shouldShowSnow(weather);
   const rainIntensity = getRainIntensity(weather);
+  const gustIntensity = getGustIntensity(weather);
+  const snowIntensity = getSnowIntensity(weather);
 
   return (
     <>
@@ -27,8 +37,8 @@ export const SeasonalEffects: React.FC<SeasonalEffectsProps> = ({ weather }) => 
       {season === 'summer' && <SummerEffects />}
       {season === 'summer' && !isDay && <Fireflies />}
       {(season === 'autumn' || season === 'winter') && <FallenLeaves />}
-      {season === 'winter' && <SnowEffect />}
-      {showRain && <RainEffect intensity={rainIntensity} />}
+      {showSnow && <SnowEffect intensity={snowIntensity} />}
+      {showRain && <RainEffect intensity={rainIntensity} gustIntensity={gustIntensity} />}
     </>
   );
 };

--- a/src/components/SnowEffect.tsx
+++ b/src/components/SnowEffect.tsx
@@ -1,7 +1,6 @@
 import React, { useRef, useMemo } from "react";
 import * as THREE from "three";
-import { useFrame } from "@react-three/fiber";
-import { useSeason } from "../contexts";
+import { useThrottledFrame } from "@/hooks/useThrottledFrame";
 import {
   SNOW_COUNT,
   SNOW_SPAWN_X_RANGE,
@@ -70,8 +69,11 @@ const createSnowflakeTexture = (() => {
  * 冬の雪エフェクト
  * 降り積もる雪をパーティクルシステムで表現
  */
-const SnowEffect: React.FC = React.memo(() => {
-  const { season } = useSeason();
+interface SnowEffectProps {
+  intensity?: number;
+}
+
+const SnowEffect: React.FC<SnowEffectProps> = React.memo(({ intensity = 1 }) => {
   const snowRef = useRef<THREE.Points>(null);
 
   // 雪のパーティクル生成
@@ -94,7 +96,7 @@ const SnowEffect: React.FC = React.memo(() => {
     return { positions, velocities };
   }, []);
 
-  useFrame((state, delta) => {
+  useThrottledFrame((state, delta) => {
     if (!snowRef.current) return;
 
     const positions = snowRef.current.geometry.attributes.position.array as Float32Array;
@@ -125,11 +127,7 @@ const SnowEffect: React.FC = React.memo(() => {
     }
 
     snowRef.current.geometry.attributes.position.needsUpdate = true;
-  });
-
-  if (season !== "winter") {
-    return null;
-  }
+  }, 30);
 
   return (
     <points ref={snowRef}>
@@ -146,7 +144,7 @@ const SnowEffect: React.FC = React.memo(() => {
         size={SNOW_SIZE}
         color={SNOW_COLOR}
         transparent
-        opacity={SNOW_OPACITY}
+        opacity={SNOW_OPACITY * (0.45 + intensity * 0.55)}
         sizeAttenuation
         map={createSnowflakeTexture()}
         alphaTest={SNOW_ALPHA_TEST}

--- a/src/components/WeatherAtmosphere.tsx
+++ b/src/components/WeatherAtmosphere.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useMemo, useRef } from "react";
+import * as THREE from "three";
+import { useThrottledFrame } from "@/hooks/useThrottledFrame";
+import { getFogIntensity, type WeatherSnapshot } from "@/utils/weather";
+
+interface WeatherAtmosphereProps {
+  backgroundColor: string;
+  isDay: boolean;
+  weather: WeatherSnapshot;
+}
+
+const pseudoRandom = (seed: number) => {
+  const value = Math.sin(seed * 12.9898) * 43758.5453;
+  return value - Math.floor(value);
+};
+
+const WeatherAtmosphere = ({ backgroundColor, isDay, weather }: WeatherAtmosphereProps) => {
+  const fog = useMemo(
+    () => new THREE.Fog(backgroundColor, 10, isDay ? 60 : 40),
+    [backgroundColor, isDay]
+  );
+  const lightningRef = useRef<THREE.PointLight>(null);
+  const fogColorRef = useRef(new THREE.Color(backgroundColor));
+
+  useEffect(() => {
+    fogColorRef.current.set(backgroundColor);
+  }, [backgroundColor]);
+
+  useThrottledFrame((state, delta) => {
+    const fogIntensity = getFogIntensity(weather);
+    const targetNear = THREE.MathUtils.lerp(isDay ? 10 : 8, 2.8, fogIntensity);
+    const targetFar = THREE.MathUtils.lerp(isDay ? 60 : 40, 13, fogIntensity);
+    const blend = Math.min(1, delta * 0.8);
+    fog.near = THREE.MathUtils.lerp(fog.near, targetNear, blend);
+    fog.far = THREE.MathUtils.lerp(fog.far, targetFar, blend);
+    fog.color.lerp(fogColorRef.current, blend);
+
+    if (!lightningRef.current) return;
+    const time = state.clock.getElapsedTime();
+    const cycle = Math.floor(time / 7);
+    const phase = time % 7;
+    const hasFlash = weather.condition === "thunderstorm" && pseudoRandom(cycle + weather.weatherCode) > 0.68;
+    const flash = hasFlash && phase < 0.22 ? Math.sin((phase / 0.22) * Math.PI) : 0;
+    lightningRef.current.intensity = flash * 7;
+  }, 20);
+
+  return (
+    <>
+      <primitive object={fog} attach="fog" />
+      <pointLight ref={lightningRef} position={[0, 18, -5]} color="#dce8ff" intensity={0} distance={80} />
+    </>
+  );
+};
+
+export default WeatherAtmosphere;

--- a/src/components/WindDirectionDisplay.tsx
+++ b/src/components/WindDirectionDisplay.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { tokens } from '@/styles/tokens';
 import { useIsMobile } from '@/hooks/useIsMobile';
+import type { WeatherLocationStatus } from '@/hooks/useWeather';
 import type { WeatherSnapshot } from '@/utils/weather';
 
 /** 風向き表示コンポーネントのプロパティ */
@@ -9,6 +10,8 @@ interface WindDirectionDisplayProps {
   windDirection: "North" | "East" | "South" | "West";
   /** 現在の天気 */
   weather: WeatherSnapshot;
+  locationStatus: WeatherLocationStatus;
+  onRequestPreciseLocation: () => void;
 }
 
 /** 風向きと表示情報のマッピング */
@@ -24,9 +27,18 @@ const formatForecastHour = (date: Date) =>
 
 const getWeatherTone = (condition: WeatherSnapshot['condition']) => {
   switch (condition) {
+    case 'thunderstorm':
+      return '遠雷';
+    case 'snow':
+      return '白い粒';
+    case 'showers':
     case 'rain':
+    case 'drizzle':
       return '雨粒';
+    case 'fog':
+      return '深まる霧';
     case 'cloudy':
+    case 'partly-cloudy':
       return 'やわらぐ光';
     case 'clear':
     default:
@@ -60,6 +72,8 @@ const panelSize = {
 const WindDirectionDisplay: React.FC<WindDirectionDisplayProps> = ({
   windDirection,
   weather,
+  locationStatus,
+  onRequestPreciseLocation,
 }) => {
   const { rotation, kanji } = windDirectionMap[windDirection];
   const [expanded, setExpanded] = useState(false);
@@ -67,8 +81,18 @@ const WindDirectionDisplay: React.FC<WindDirectionDisplayProps> = ({
   const forecastPreview = weather.forecast.slice(1, 4);
   const windSpeedText = formatWindSpeed(weather.windSpeed);
   const size = isMobile ? panelSize.mobile : panelSize.pc;
-  const sourceText =
-    weather.source === 'open-meteo' ? '現在地付近の実天気' : '水辺の天気';
+  const sourceText = weather.locationSource === 'browser'
+    ? '現在地の実天気'
+    : weather.source === 'open-meteo'
+      ? '現在地付近の実天気'
+      : '水辺の天気';
+  const locationButtonText = locationStatus === 'requesting'
+    ? '位置を確認中'
+    : locationStatus === 'precise'
+      ? '現在地を使用中'
+      : locationStatus === 'denied'
+        ? '位置情報は未許可'
+        : '現在地を使う';
 
   return (
     <div
@@ -408,8 +432,28 @@ const WindDirectionDisplay: React.FC<WindDirectionDisplayProps> = ({
             }}
           >
             風 {windSpeedText}
+            {weather.windGusts !== null && weather.windGusts > (weather.windSpeed ?? 0) + 1
+              ? ` / 突風 ${weather.windGusts.toFixed(1)}m/s`
+              : ''}
           </div>
         )}
+        <div
+          style={{
+            marginTop: '8px',
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            gap: '4px 10px',
+            fontSize: '10px',
+            fontWeight: 500,
+            color: 'rgba(255, 255, 255, 0.76)',
+            lineHeight: 1.5,
+          }}
+        >
+          <span>気温 {weather.temperature.toFixed(1)}℃</span>
+          <span>体感 {weather.apparentTemperature.toFixed(1)}℃</span>
+          <span>湿度 {Math.round(weather.humidity)}%</span>
+          <span>視程 {Math.max(0.1, weather.visibility / 1000).toFixed(1)}km</span>
+        </div>
         {forecastPreview.length > 0 && (
           <div
             style={{
@@ -485,6 +529,27 @@ const WindDirectionDisplay: React.FC<WindDirectionDisplayProps> = ({
             </div>
           </div>
         )}
+        <button
+          type="button"
+          onClick={onRequestPreciseLocation}
+          disabled={locationStatus === 'requesting' || locationStatus === 'precise'}
+          style={{
+            width: '100%',
+            marginTop: '10px',
+            padding: '7px 8px',
+            border: '1px solid rgba(255, 255, 255, 0.2)',
+            borderRadius: '8px',
+            background: 'rgba(255, 255, 255, 0.08)',
+            color: 'rgba(255, 255, 255, 0.86)',
+            fontFamily: tokens.typography.fontFamily.serif,
+            fontSize: '10px',
+            fontWeight: 600,
+            cursor: locationStatus === 'requesting' || locationStatus === 'precise' ? 'default' : 'pointer',
+            opacity: locationStatus === 'requesting' ? 0.65 : 1,
+          }}
+        >
+          {locationButtonText}
+        </button>
       </div>
       )}
     </div>

--- a/src/hooks/useWeather.ts
+++ b/src/hooks/useWeather.ts
@@ -1,33 +1,90 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { WEATHER_REFRESH_INTERVAL_MS } from "@/constants/weather";
-import { fetchWeather, getFallbackWeather } from "@/utils/weather";
+import {
+  directWeatherSnapshot,
+  fetchWeather,
+  getFallbackWeather,
+  type WeatherSnapshot,
+} from "@/utils/weather";
 
-/**
- * 現在の擬似天気を管理する。
- * 天気は日付と3時間帯から決定するため、リロードしても同じ時間帯は変わらない。
- */
+export type WeatherLocationStatus = "approximate" | "requesting" | "precise" | "denied" | "unavailable";
+
+interface StoredCoordinates {
+  latitude: number;
+  longitude: number;
+}
+
+const LOCATION_SESSION_KEY = "mizube_weather_coordinates";
+const DIRECTOR_INTERVAL_MS = 10_000;
+
+const loadStoredCoordinates = (): StoredCoordinates | null => {
+  try {
+    const raw = window.sessionStorage.getItem(LOCATION_SESSION_KEY);
+    if (!raw) return null;
+    const value = JSON.parse(raw) as StoredCoordinates;
+    return Number.isFinite(value.latitude) && Number.isFinite(value.longitude) ? value : null;
+  } catch {
+    return null;
+  }
+};
+
 export const useWeather = () => {
-  const [weather, setWeather] = useState(() => getFallbackWeather());
+  const [rawWeather, setRawWeather] = useState<WeatherSnapshot>(() => getFallbackWeather());
+  const [weather, setWeather] = useState<WeatherSnapshot>(() => getFallbackWeather());
+  const [locationStatus, setLocationStatus] = useState<WeatherLocationStatus>("approximate");
+  const coordinatesRef = useRef<StoredCoordinates | null>(null);
 
-  useEffect(() => {
-    let disposed = false;
-
-    const updateWeather = async () => {
-      const nextWeather = await fetchWeather();
-      if (!disposed) {
-        setWeather(nextWeather ?? getFallbackWeather());
-      }
-    };
-
-    updateWeather();
-
-    const interval = setInterval(updateWeather, WEATHER_REFRESH_INTERVAL_MS);
-
-    return () => {
-      disposed = true;
-      clearInterval(interval);
-    };
+  const updateWeather = useCallback(async (coordinates = coordinatesRef.current) => {
+    const nextWeather = await fetchWeather(coordinates ?? {});
+    const resolved = nextWeather ?? getFallbackWeather();
+    setRawWeather(resolved);
+    setWeather(directWeatherSnapshot(resolved));
+    if (resolved.locationSource === "browser") setLocationStatus("precise");
   }, []);
 
-  return weather;
+  useEffect(() => {
+    const stored = loadStoredCoordinates();
+    coordinatesRef.current = stored;
+    if (stored) setLocationStatus("precise");
+    void updateWeather(stored);
+
+    const refreshInterval = window.setInterval(() => void updateWeather(), WEATHER_REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(refreshInterval);
+  }, [updateWeather]);
+
+  useEffect(() => {
+    setWeather(directWeatherSnapshot(rawWeather));
+    const directorInterval = window.setInterval(
+      () => setWeather(directWeatherSnapshot(rawWeather)),
+      DIRECTOR_INTERVAL_MS
+    );
+    return () => window.clearInterval(directorInterval);
+  }, [rawWeather]);
+
+  const requestPreciseLocation = useCallback(() => {
+    if (!navigator.geolocation) {
+      setLocationStatus("unavailable");
+      return;
+    }
+
+    setLocationStatus("requesting");
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const coordinates = {
+          latitude: position.coords.latitude,
+          longitude: position.coords.longitude,
+        };
+        coordinatesRef.current = coordinates;
+        window.sessionStorage.setItem(LOCATION_SESSION_KEY, JSON.stringify(coordinates));
+        setLocationStatus("precise");
+        void updateWeather(coordinates);
+      },
+      (error) => {
+        setLocationStatus(error.code === error.PERMISSION_DENIED ? "denied" : "unavailable");
+      },
+      { enableHighAccuracy: false, timeout: 10_000, maximumAge: 30 * 60 * 1000 }
+    );
+  }, [updateWeather]);
+
+  return { weather, locationStatus, requestPreciseLocation };
 };

--- a/src/utils/bottleJournal.ts
+++ b/src/utils/bottleJournal.ts
@@ -52,18 +52,42 @@ const windLabels: Record<WindDirection, string> = {
   West: "西",
 };
 
-const weatherNotes = {
+const weatherNotes: Record<WeatherSnapshot["condition"], readonly string[]> = {
   clear: [
     "空は明るく、水面の光もよく届いていた",
     "晴れた気配の中で、水の色が少し澄んで見えた",
+  ],
+  "partly-cloudy": [
+    "雲間の光が水面をゆっくり横切った",
+    "薄い雲の影が、岸から岸へ静かに流れた",
   ],
   cloudy: [
     "雲が光をやわらげ、水辺の影も静かだった",
     "曇り空の下で、水面の反射が落ち着いていた",
   ],
+  fog: [
+    "霧が水辺の輪郭を近くへ引き寄せていた",
+    "遠い岸が白くほどけ、水音だけが残っていた",
+  ],
+  drizzle: [
+    "細かな雨が、水面に淡い粒を重ねていた",
+    "霧雨が岸辺を薄く濡らし続けていた",
+  ],
   rain: [
     "雨粒が落ちるたび、水面に小さな輪が増えた",
     "雨の気配で、岸辺の音が少し近く聞こえた",
+  ],
+  showers: [
+    "通り雨が水面を駆け抜け、すぐ遠ざかった",
+    "強い雨粒が短いあいだ池の音を満たした",
+  ],
+  snow: [
+    "白い粒が水辺へ落ち、音をひとつずつ消していた",
+    "雪が水面の上でほどけ、冷たい光だけを残した",
+  ],
+  thunderstorm: [
+    "遠い空が光り、少し遅れて水辺へ響いた",
+    "雷の気配に合わせて、水面の影が一瞬揺れた",
   ],
 } as const;
 
@@ -155,12 +179,22 @@ export const createDailyLifeLog = ({
   const seasonalText = pick(seasonNotes[season], seed);
   const timeText = pick(timeNotes[timeOfDay], seed >>> 3);
   const weatherText = pick(weatherNotes[weather.condition], seed >>> 5);
-  const weatherSourceText =
-    weather.source === "open-meteo" ? `${weather.location}の${weather.label}。` : "";
+  const weatherSourceText = weather.source === "open-meteo"
+    ? `${weather.locationSource === "browser" ? "現在地" : "近く"}の空は${weather.label}。`
+    : "";
   const windText = `${windLabels[windDirection]}からの風。`;
   const forecastText = weather.forecastSummary ? `${weather.forecastSummary}。` : "";
+  const eventText = weather.trend === "worsening"
+    ? "空模様は少しずつ深まっていた。"
+    : weather.trend === "clearing"
+      ? "雲の向こうから光が戻ろうとしていた。"
+      : (weather.windGusts ?? 0) >= 8
+        ? "時折、強い風が水面を走った。"
+        : weather.visibility < 8_000
+          ? "遠い岸は淡い空気の中に隠れていた。"
+          : "";
 
-  return `${formatJournalDate(date)}、${seasonLabels[season]}の${timeLabels[timeOfDay]}。${weatherSourceText}${seasonalText}。${weatherText}。${forecastText}${timeText}。${windText}`;
+  return `${formatJournalDate(date)}、${seasonLabels[season]}の${timeLabels[timeOfDay]}。${weatherSourceText}${seasonalText}。${weatherText}。${eventText}${forecastText}${timeText}。${windText}`;
 };
 
 export const loadBottleJournal = (): BottleJournalEntry[] => {

--- a/src/utils/weather.ts
+++ b/src/utils/weather.ts
@@ -8,18 +8,40 @@ import {
   WEATHER_TIME_BLOCK_HOURS,
 } from "@/constants/weather";
 
-export type WeatherCondition = "clear" | "cloudy" | "rain";
+export type WeatherCondition =
+  | "clear"
+  | "partly-cloudy"
+  | "cloudy"
+  | "fog"
+  | "drizzle"
+  | "rain"
+  | "showers"
+  | "snow"
+  | "thunderstorm";
+
+export type WeatherLocationSource = "browser" | "cloudflare" | "fallback";
+export type WeatherTrend = "steady" | "clearing" | "worsening";
 
 export interface WeatherForecastPoint {
   time: Date;
   condition: WeatherCondition;
   label: string;
   description: string;
+  weatherCode: number;
+  temperature: number;
+  apparentTemperature: number;
+  humidity: number;
   precipitation: number;
+  rain: number;
+  snowfall: number;
   precipitationProbability: number | null;
   cloudCover: number;
+  visibility: number;
   windDirection: number;
   windSpeed: number;
+  windGusts: number;
+  solarRadiation: number;
+  isDay: boolean;
 }
 
 export interface WeatherSnapshot {
@@ -29,60 +51,93 @@ export interface WeatherSnapshot {
   observedAt: Date;
   source: "open-meteo" | "fallback";
   location: string;
+  locationSource: WeatherLocationSource;
+  weatherCode: number;
+  temperature: number;
+  apparentTemperature: number;
+  humidity: number;
   precipitation: number;
+  rain: number;
+  snowfall: number;
   cloudCover: number;
+  visibility: number;
   windDirection: number | null;
   windSpeed: number | null;
+  windGusts: number | null;
+  solarRadiation: number;
+  isDay: boolean;
+  sunrise: Date | null;
+  sunset: Date | null;
   forecast: WeatherForecastPoint[];
   forecastSummary: string;
+  trend: WeatherTrend;
 }
 
-interface WeatherApiResponse {
-  condition: WeatherCondition;
-  label: string;
-  description: string;
+interface WeatherApiResponse extends Omit<WeatherSnapshot, "observedAt" | "sunrise" | "sunset" | "forecast" | "forecastSummary" | "trend"> {
   observedAt: string;
-  source: "open-meteo";
-  location: string;
-  precipitation: number;
-  cloudCover: number;
-  windDirection: number;
-  windSpeed: number;
-  forecast?: Array<{
-    time: string;
-    condition: WeatherCondition;
-    label: string;
-    description: string;
-    precipitation: number;
-    precipitationProbability: number | null;
-    cloudCover: number;
-    windDirection: number;
-    windSpeed: number;
-  }>;
+  sunrise: string | null;
+  sunset: string | null;
+  forecast?: Array<Omit<WeatherForecastPoint, "time"> & { time: string }>;
 }
 
-const weatherLabels: Record<WeatherCondition, string> = {
+export const weatherLabels: Record<WeatherCondition, string> = {
   clear: "晴",
+  "partly-cloudy": "薄曇",
   cloudy: "曇",
+  fog: "霧",
+  drizzle: "霧雨",
   rain: "雨",
+  showers: "にわか雨",
+  snow: "雪",
+  thunderstorm: "雷雨",
 };
 
-const weatherDescriptions: Record<WeatherCondition, string> = {
+export const weatherDescriptions: Record<WeatherCondition, string> = {
   clear: "水面がよく光る",
+  "partly-cloudy": "雲間から光が差す",
   cloudy: "光がやわらぐ",
+  fog: "水辺に霧が漂う",
+  drizzle: "細かな雨が水面を撫でる",
   rain: "雨粒が落ちる",
+  showers: "雨脚が近づいては離れる",
+  snow: "白い粒が静かに落ちる",
+  thunderstorm: "遠くで空が鳴る",
 };
 
 const fallbackPrecipitation: Record<WeatherCondition, number> = {
   clear: 0,
+  "partly-cloudy": 0,
   cloudy: 0,
+  fog: 0,
+  drizzle: 0.25,
   rain: 1.2,
+  showers: 1.8,
+  snow: 0.6,
+  thunderstorm: 3.2,
 };
 
 const fallbackCloudCover: Record<WeatherCondition, number> = {
   clear: 18,
+  "partly-cloudy": 42,
   cloudy: 68,
+  fog: 88,
+  drizzle: 82,
   rain: 92,
+  showers: 78,
+  snow: 90,
+  thunderstorm: 96,
+};
+
+const conditionSeverity: Record<WeatherCondition, number> = {
+  clear: 0,
+  "partly-cloudy": 1,
+  cloudy: 2,
+  fog: 3,
+  drizzle: 4,
+  snow: 5,
+  rain: 6,
+  showers: 7,
+  thunderstorm: 8,
 };
 
 const getJapanDate = (date: Date) =>
@@ -97,40 +152,46 @@ const getWeatherScore = (date: Date) => {
 
   return {
     month,
-    score:
-      (year + month * 11 + day * 37 + timeBlock * 17) %
-      WEATHER_SCORE_BUCKETS,
+    score: (year + month * 11 + day * 37 + timeBlock * 17) % WEATHER_SCORE_BUCKETS,
   };
 };
 
 const getFallbackCondition = (date: Date): WeatherCondition => {
   const { month, score } = getWeatherScore(date);
   const rainThreshold =
-    month === RAINY_SEASON_MONTH
-      ? RAINY_SEASON_RAIN_THRESHOLD
-      : DEFAULT_RAIN_THRESHOLD;
+    month === RAINY_SEASON_MONTH ? RAINY_SEASON_RAIN_THRESHOLD : DEFAULT_RAIN_THRESHOLD;
   const cloudyThreshold =
     month === RAINY_SEASON_MONTH
       ? RAINY_SEASON_CLOUDY_THRESHOLD
       : DEFAULT_CLOUDY_THRESHOLD;
 
-  return score < rainThreshold
-    ? "rain"
-    : score < cloudyThreshold
-      ? "cloudy"
-      : "clear";
+  return score < rainThreshold ? "rain" : score < cloudyThreshold ? "cloudy" : "clear";
 };
 
-const createForecastSummary = (forecast: WeatherForecastPoint[]) => {
+const getTrend = (condition: WeatherCondition, forecast: WeatherForecastPoint[]): WeatherTrend => {
+  const next = forecast.find((point) => point.time.getTime() > Date.now() + 20 * 60 * 1000);
+  if (!next) return "steady";
+  const difference = conditionSeverity[next.condition] - conditionSeverity[condition];
+  if (difference >= 2) return "worsening";
+  if (difference <= -2) return "clearing";
+  return "steady";
+};
+
+export const createForecastSummary = (
+  forecast: WeatherForecastPoint[],
+  currentCondition: WeatherCondition = forecast[0]?.condition ?? "clear"
+) => {
   const upcoming = forecast.slice(1, 4);
-  if (upcoming.some((point) => point.condition === "rain")) {
+  if (upcoming.some((point) => point.condition === "thunderstorm")) return "遠くで雷の気配がする";
+  if (upcoming.some((point) => point.condition === "snow")) return "このあと白い粒が近づく";
+  if (upcoming.some((point) => ["rain", "showers", "drizzle"].includes(point.condition))) {
     return "このあと雨粒が近づく";
   }
-
-  if (upcoming.some((point) => point.condition === "clear")) {
+  if (upcoming.some((point) => point.condition === "fog")) return "このあと霧が深くなる";
+  if (conditionSeverity[currentCondition] >= 3 && upcoming.some((point) => point.condition === "clear")) {
     return "このあと光が戻る";
   }
-
+  if (upcoming.some((point) => point.condition === "clear")) return "雲間から光が戻る";
   return "しばらく光はやわらかい";
 };
 
@@ -138,72 +199,143 @@ const createFallbackForecast = (date: Date): WeatherForecastPoint[] =>
   Array.from({ length: 6 }, (_, index) => {
     const forecastDate = new Date(date.getTime() + index * 60 * 60 * 1000);
     const condition = getFallbackCondition(forecastDate);
-
+    const precipitation = fallbackPrecipitation[condition];
     return {
       time: getJapanDate(forecastDate),
       condition,
       label: weatherLabels[condition],
       description: weatherDescriptions[condition],
-      precipitation: fallbackPrecipitation[condition],
+      weatherCode: condition === "rain" ? 61 : condition === "cloudy" ? 3 : 0,
+      temperature: 18,
+      apparentTemperature: 18,
+      humidity: condition === "rain" ? 88 : condition === "cloudy" ? 72 : 56,
+      precipitation,
+      rain: condition === "rain" ? precipitation : 0,
+      snowfall: 0,
       precipitationProbability: condition === "rain" ? 72 : condition === "cloudy" ? 28 : 8,
       cloudCover: fallbackCloudCover[condition],
+      visibility: condition === "rain" ? 9_000 : 20_000,
       windDirection: (forecastDate.getHours() * 35 + index * 23) % 360,
       windSpeed: condition === "rain" ? 4.8 : condition === "cloudy" ? 3.1 : 2.2,
+      windGusts: condition === "rain" ? 7.2 : 4.2,
+      solarRadiation: condition === "clear" ? 420 : condition === "cloudy" ? 140 : 50,
+      isDay: forecastDate.getHours() >= 6 && forecastDate.getHours() < 18,
     };
   });
 
 export const getFallbackWeather = (date = new Date()): WeatherSnapshot => {
   const condition = getFallbackCondition(date);
   const forecast = createFallbackForecast(date);
-
+  const japanDate = getJapanDate(date);
   return {
     condition,
     label: weatherLabels[condition],
     description: weatherDescriptions[condition],
-    observedAt: getJapanDate(date),
+    observedAt: japanDate,
     source: "fallback",
     location: "水辺",
-    precipitation: fallbackPrecipitation[condition],
+    locationSource: "fallback",
+    weatherCode: forecast[0].weatherCode,
+    temperature: forecast[0].temperature,
+    apparentTemperature: forecast[0].apparentTemperature,
+    humidity: forecast[0].humidity,
+    precipitation: forecast[0].precipitation,
+    rain: forecast[0].rain,
+    snowfall: 0,
     cloudCover: fallbackCloudCover[condition],
+    visibility: forecast[0].visibility,
     windDirection: null,
     windSpeed: null,
+    windGusts: null,
+    solarRadiation: forecast[0].solarRadiation,
+    isDay: forecast[0].isDay,
+    sunrise: null,
+    sunset: null,
     forecast,
-    forecastSummary: createForecastSummary(forecast),
+    forecastSummary: createForecastSummary(forecast, condition),
+    trend: getTrend(condition, forecast),
   };
 };
 
-export const fetchWeather = async (): Promise<WeatherSnapshot | null> => {
-  try {
-    const response = await fetch("/api/weather");
-    if (!response.ok) {
-      return null;
-    }
+const lerp = (start: number, end: number, progress: number) => start + (end - start) * progress;
 
-    const contentType = response.headers.get("content-type");
-    if (!contentType?.includes("application/json")) {
-      return null;
+const lerpDirection = (start: number, end: number, progress: number) => {
+  const delta = ((end - start + 540) % 360) - 180;
+  return (start + delta * progress + 360) % 360;
+};
+
+export const directWeatherSnapshot = (snapshot: WeatherSnapshot, now = new Date()): WeatherSnapshot => {
+  if (snapshot.forecast.length < 2) return snapshot;
+  const nowTime = now.getTime();
+  let before = snapshot.forecast[0];
+  let after = snapshot.forecast[1];
+
+  for (let index = 0; index < snapshot.forecast.length - 1; index += 1) {
+    const candidate = snapshot.forecast[index];
+    const next = snapshot.forecast[index + 1];
+    if (candidate.time.getTime() <= nowTime && next.time.getTime() >= nowTime) {
+      before = candidate;
+      after = next;
+      break;
     }
+  }
+
+  const duration = Math.max(1, after.time.getTime() - before.time.getTime());
+  const progress = Math.max(0, Math.min(1, (nowTime - before.time.getTime()) / duration));
+  const conditionPoint = progress < 0.58 ? before : after;
+  const directed: WeatherSnapshot = {
+    ...snapshot,
+    condition: conditionPoint.condition,
+    label: conditionPoint.label,
+    description: conditionPoint.description,
+    weatherCode: conditionPoint.weatherCode,
+    temperature: lerp(before.temperature, after.temperature, progress),
+    apparentTemperature: lerp(before.apparentTemperature, after.apparentTemperature, progress),
+    humidity: lerp(before.humidity, after.humidity, progress),
+    precipitation: lerp(before.precipitation, after.precipitation, progress),
+    rain: lerp(before.rain, after.rain, progress),
+    snowfall: lerp(before.snowfall, after.snowfall, progress),
+    cloudCover: lerp(before.cloudCover, after.cloudCover, progress),
+    visibility: lerp(before.visibility, after.visibility, progress),
+    windDirection: lerpDirection(before.windDirection, after.windDirection, progress),
+    windSpeed: lerp(before.windSpeed, after.windSpeed, progress),
+    windGusts: lerp(before.windGusts, after.windGusts, progress),
+    solarRadiation: lerp(before.solarRadiation, after.solarRadiation, progress),
+    isDay: conditionPoint.isDay,
+  };
+  directed.forecastSummary = createForecastSummary(snapshot.forecast, directed.condition);
+  directed.trend = getTrend(directed.condition, snapshot.forecast);
+  return directed;
+};
+
+interface FetchWeatherOptions {
+  latitude?: number;
+  longitude?: number;
+}
+
+export const fetchWeather = async (options: FetchWeatherOptions = {}): Promise<WeatherSnapshot | null> => {
+  try {
+    const url = new URL("/api/weather", window.location.origin);
+    if (options.latitude !== undefined && options.longitude !== undefined) {
+      url.searchParams.set("latitude", String(options.latitude));
+      url.searchParams.set("longitude", String(options.longitude));
+    }
+    const response = await fetch(url);
+    if (!response.ok) return null;
+    if (!response.headers.get("content-type")?.includes("application/json")) return null;
 
     const data: WeatherApiResponse = await response.json();
-    const forecast = (data.forecast ?? []).map((point) => ({
-      ...point,
-      time: new Date(point.time),
-    }));
-
-    return {
-      condition: data.condition,
-      label: data.label,
-      description: data.description,
+    const forecast = (data.forecast ?? []).map((point) => ({ ...point, time: new Date(point.time) }));
+    const snapshot: WeatherSnapshot = {
+      ...data,
       observedAt: new Date(data.observedAt),
-      source: data.source,
-      location: data.location,
-      precipitation: data.precipitation,
-      cloudCover: data.cloudCover,
-      windDirection: data.windDirection,
-      windSpeed: data.windSpeed,
+      sunrise: data.sunrise ? new Date(data.sunrise) : null,
+      sunset: data.sunset ? new Date(data.sunset) : null,
       forecast,
-      forecastSummary: createForecastSummary(forecast),
+      forecastSummary: createForecastSummary(forecast, data.condition),
+      trend: getTrend(data.condition, forecast),
     };
+    return directWeatherSnapshot(snapshot);
   } catch (error) {
     console.error("Error fetching weather:", error);
     return null;
@@ -211,25 +343,43 @@ export const fetchWeather = async (): Promise<WeatherSnapshot | null> => {
 };
 
 export const shouldShowRain = (weather: WeatherSnapshot) =>
-  weather.condition === "rain";
+  ["drizzle", "rain", "showers", "thunderstorm"].includes(weather.condition) && weather.rain > 0;
+
+export const shouldShowSnow = (weather: WeatherSnapshot) =>
+  weather.condition === "snow" || weather.snowfall > 0;
 
 export const getRainIntensity = (weather: WeatherSnapshot) => {
-  const current = Math.min(1, weather.precipitation / 4);
-  const nearFuture = Math.max(
-    0,
-    ...weather.forecast.slice(0, 3).map((point) => Math.min(1, point.precipitation / 4))
-  );
-  return Math.max(current, nearFuture * 0.45);
+  const current = Math.min(1, weather.rain / 4);
+  const nearFuture = Math.max(0, ...weather.forecast.slice(0, 3).map((point) => Math.min(1, point.rain / 4)));
+  return Math.max(current, nearFuture * 0.38);
 };
+
+export const getSnowIntensity = (weather: WeatherSnapshot) => Math.min(1, weather.snowfall / 2.5);
 
 export const getCloudIntensity = (weather: WeatherSnapshot) =>
   Math.max(0, Math.min(1, weather.cloudCover / 100));
 
+export const getFogIntensity = (weather: WeatherSnapshot) => {
+  const visibilityFog = 1 - Math.min(1, weather.visibility / 16_000);
+  const humidityFog = Math.max(0, (weather.humidity - 78) / 22);
+  return Math.max(weather.condition === "fog" ? 0.72 : 0, visibilityFog * 0.8 + humidityFog * 0.2);
+};
+
+export const getGustIntensity = (weather: WeatherSnapshot) => {
+  const speed = weather.windSpeed ?? 0;
+  const gust = weather.windGusts ?? speed;
+  return Math.max(0, Math.min(1, (gust - speed) / 8 + gust / 24));
+};
+
+export const getSolarIntensity = (weather: WeatherSnapshot) =>
+  weather.isDay ? Math.max(0.08, Math.min(1, weather.solarRadiation / 650)) : 0;
+
 export const getWaterReflectionIntensity = (weather: WeatherSnapshot) => {
-  const cloudDimming = getCloudIntensity(weather) * 0.45;
+  const cloudDimming = getCloudIntensity(weather) * 0.42;
   const rainDimming = getRainIntensity(weather) * 0.35;
-  return Math.max(0.25, 1 - cloudDimming - rainDimming);
+  const fogDimming = getFogIntensity(weather) * 0.25;
+  return Math.max(0.2, 0.55 + getSolarIntensity(weather) * 0.45 - cloudDimming - rainDimming - fogDimming);
 };
 
 export const getWeatherWaterTurbulence = (weather: WeatherSnapshot) =>
-  1 + getRainIntensity(weather) * 0.65 + getCloudIntensity(weather) * 0.12;
+  1 + getRainIntensity(weather) * 0.65 + getCloudIntensity(weather) * 0.12 + getGustIntensity(weather) * 0.4;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,14 @@ const matchesPackage = (id: string, pkg: string) => id.includes(`/node_modules/$
 
 // https://vite.dev/config/
 export default defineConfig({
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://127.0.0.1:8788",
+        changeOrigin: true,
+      },
+    },
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## 概要
- 実況と時間別予報を補間し、天候変化を滑らかに反映
- 霧・雷・突風・日射・降雪を水辺の演出へ連動
- 任意の現在地取得と天気日記の表現を拡張

## 変更内容
- Open-Meteo APIから湿度、視程、突風、日射、日の出・日の入りを取得
- 雲、雨、雪、照明、魚、水面の天候連動を追加
- 天候に応じた背景色とフォグの遷移を追加
- 現在地取得UIとVite開発用APIプロキシを追加

## テスト計画
- [x] 型チェック通過
- [x] Lint通過
- [x] ビルド成功
- [x] デスクトップ・モバイル動作確認完了

🤖 Generated with [Codex CLI](https://openai.com/codex)