### PR TITLE
refactor: シーン構成をAppから分離

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,40 +1,12 @@
-import React, { Suspense, useRef, useMemo, memo, useState, useEffect, useCallback } from "react";
+import React, { useMemo, memo, useState, useEffect, useCallback } from "react";
 
 import { SeasonProvider, TimeProvider, useDayPeriod } from "./contexts";
-import { Canvas } from "@react-three/fiber";
-import { OrbitControls, useProgress } from "@react-three/drei";
-import * as THREE from "three";
-import FishManager from "./components/FishManager";
-import ParticleLayerInstanced from "./components/ParticleLayerInstanced";
-import Clouds from "./components/Clouds";
 import WindDirectionDisplay from "./components/WindDirectionDisplay";
-import WeatherAtmosphere from "./components/WeatherAtmosphere";
-import Ground from "./components/Ground";
-import Stars from "./components/Stars";
-import ShootingStars from "./components/ShootingStars";
-import ReflectedStars from "./components/ReflectedStars";
-import WaterSurface from "./components/WaterSurface";
-import LightingController from "./components/LightingController";
-import SundialGnomon from "./components/SundialGnomon";
-import SundialBase from "./components/SundialBase";
 import Loader from "./components/Loader";
-import { DriftingBottle } from "./components/DriftingBottle";
-import { Sun } from "./components/Sun";
-import { SceneLights } from "./components/SceneLights";
-import { SeasonalEffects } from "./components/SeasonalEffects";
-// import { DebugHelpers } from "./components/DebugHelpers"; // デバッグヘルパーは削除
-import { PerformanceMonitorCollector, PerformanceMonitorDisplay } from "./components/PerformanceMonitor";
-
-const WaterPlantsLarge = React.lazy(
-  () => import("./components/WaterPlantsLarge")
-);
-const PottedPlant = React.lazy(() => import("./components/PottedPlant"));
-const Rocks = React.lazy(() => import("./components/Rocks"));
-const BubbleEffect = React.lazy(() => import("./components/BubbleEffect"));
-
+import { PerformanceMonitorDisplay } from "./components/PerformanceMonitor";
+import SceneCanvas from "./components/SceneCanvas";
 import UI from "./components/UI";
 import "./App.css";
-import { SIMULATED_SECONDS_PER_REAL_SECOND } from "./constants/core";
 import { useIsMobile } from "./hooks/useIsMobile";
 import { useWindDirection } from "./hooks/useWindDirection";
 import { useWeather } from "./hooks/useWeather";
@@ -59,47 +31,7 @@ const getWindDirectionFromDegrees = (
   return "West";
 };
 
-// メモ化されたコンポーネント
-const MemoizedGround = memo(Ground);
-const MemoizedFishManager = memo(FishManager);
-const MemoizedParticleLayerInstanced = memo(ParticleLayerInstanced);
-const MemoizedClouds = memo(Clouds);
-const MemoizedStars = memo(Stars);
-const MemoizedShootingStars = memo(ShootingStars);
-const MemoizedReflectedStars = memo(ReflectedStars);
-const MemoizedWaterSurface = memo(WaterSurface);
-// SundialGnomonは内部で太陽位置を参照するのでメモ化のみ行う
-const MemoizedSundialGnomon = memo(SundialGnomon);
-const MemoizedSundialBase = memo(SundialBase);
-const MemoizedDriftingBottle = memo(DriftingBottle);
-const MemoizedSeasonalEffects = memo(SeasonalEffects);
 const MemoizedWindDirectionDisplay = memo(WindDirectionDisplay);
-
-/**
- * Canvas内でThree.jsの読み込み状況を監視し、完了時に親へ通知
- */
-const LoadingTracker = ({
-  onLoaded,
-  onProgress
-}: {
-  onLoaded: () => void;
-  onProgress: (progress: number, loadingText: string) => void;
-}) => {
-  const { active, progress, loaded, total } = useProgress();
-
-  useEffect(() => {
-    if (active) {
-      const percentComplete = (loaded / total) * 100;
-      const text = `3Dモデルを読み込み中... (${loaded}/${total})`;
-      onProgress(percentComplete, text);
-    } else {
-      onProgress(100, "完了");
-      onLoaded();
-    }
-  }, [active, progress, loaded, total, onLoaded, onProgress]);
-
-  return null;
-};
 
 const MINIMUM_LOADER_MS = 300;
 type AppStyle = React.CSSProperties & { "--app-background-color"?: string };
@@ -124,33 +56,9 @@ const AppContent = () => {
   const [loadingProgress, setLoadingProgress] = useState(0);
   const [loadingText, setLoadingText] = useState("初期化中...");
   const isLoading = !(assetsLoaded && minDelayElapsed);
-  const directionalLightRef = useRef<THREE.DirectionalLight | null>(null);
-  const ambientLightRef = useRef<THREE.AmbientLight | null>(null);
-  const pointLightRef = useRef<THREE.PointLight | null>(null);
-  const spotLightRef = useRef<THREE.SpotLight | null>(null);
 
   // 背景色をメモ化
   const backgroundColor = useMemo(() => isDay ? "#4A90E2" : "#2A2A4E", [isDay]);
-  const cameraConfig = useMemo<{ position: [number, number, number]; fov: number }>(
-    () => ({
-      position: [5, 3, 0],
-      fov: isMobile ? 75 : 70,
-    }),
-    [isMobile]
-  );
-  const rendererConfig = useMemo<THREE.WebGLRendererParameters>(
-    () => ({
-      antialias: !isMobile,
-      powerPreference: "high-performance",
-      alpha: false,
-      stencil: false,
-    }),
-    [isMobile]
-  );
-  const canvasDpr = useMemo<[number, number]>(
-    () => (isMobile ? [0.75, 1.25] : [1, 1.75]),
-    [isMobile]
-  );
 
   // 最低表示時間を確保
   useEffect(() => {
@@ -188,139 +96,50 @@ const AppContent = () => {
   };
 
   return (
-      <div
-        className="App"
-        style={appStyle}
-      >
-        {showLoader && (
-          <Loader
-            progress={loadingProgress}
-            loadingText={loadingText}
-            isExiting={!isLoading}
-          />
-        )}
-        <Canvas
-          className="App-canvas"
-          camera={cameraConfig}
-          gl={rendererConfig}
-          dpr={canvasDpr}
-          frameloop="always" // 常にレンダリング
-          performance={{ min: 0.5 }} // パフォーマンス低下時の最小品質
-        >
-          {/* Three.jsローダーの完了を検知 */}
-          <LoadingTracker onLoaded={handleAssetsLoaded} onProgress={handleProgress} />
-          {!isDay && (
-            <>
-              <MemoizedStars />
-              <MemoizedShootingStars />
-              <MemoizedReflectedStars />
-            </>
-          )}
-
-          {/* シーンの背景と霧 */}
-          <color attach="background" args={[backgroundColor]} />
-          <WeatherAtmosphere
-            backgroundColor={backgroundColor}
-            isDay={isDay}
-            weather={weather}
-          />
-
-          {/* ライティング */}
-          <SceneLights
-            directionalLightRef={directionalLightRef}
-            ambientLightRef={ambientLightRef}
-            pointLightRef={pointLightRef}
-            spotLightRef={spotLightRef}
-          />
-          <LightingController
-            directionalLightRef={directionalLightRef}
-            ambientLightRef={ambientLightRef}
-            pointLightRef={pointLightRef}
-            spotLightRef={spotLightRef}
-            weather={weather}
-          />
-
-          {/* 太陽 */}
-          <Sun />
-          {/* カメラコントロール */}
-          <OrbitControls
-            enableZoom={true}
-            enablePan={true}
-            enableRotate={true}
-            maxDistance={20}
-            minDistance={1}
-            dampingFactor={0.1}
-            enableDamping={true}
-          />
-
-          {/* 初期表示の核になる軽量オブジェクト */}
-          <MemoizedGround />
-          <MemoizedWaterSurface
-            weather={weather}
-            onInteract={uxHints.markWaterRippled}
-          />
-          <MemoizedSundialGnomon />
-          <MemoizedSundialBase />
-
-          {/* モデル・装飾系は初期描画をブロックしない */}
-          <Suspense fallback={null}>
-            <MemoizedFishManager weather={weather} />
-          </Suspense>
-          <Suspense fallback={null}>
-            <WaterPlantsLarge />
-            <PottedPlant />
-            <Rocks />
-            <BubbleEffect />
-          </Suspense>
-          <Suspense fallback={null}>
-            <MemoizedDriftingBottle
-              position={[-3, 8.2, 2]}
-              onMessageRead={uxHints.markBottleOpened}
-              showHint={!isLoading && uxHints.shouldShowBottleHint}
-              windDirection={windDirection}
-              weather={weather}
-            />
-          </Suspense>
-          <Suspense fallback={null}>
-            <MemoizedParticleLayerInstanced />
-            <MemoizedClouds
-              weather={weather}
-              timeScale={SIMULATED_SECONDS_PER_REAL_SECOND / 60}
-            />
-          </Suspense>
-
-          {/* 季節エフェクト */}
-          <Suspense fallback={null}>
-            <MemoizedSeasonalEffects weather={weather} />
-          </Suspense>
-
-          {/* デバッグヘルパー - 削除 */}
-          {/* <DebugHelpers enabled={DEBUG_MODE} /> */}
-          {/* パフォーマンスモニター - データ収集（Canvas内） */}
-          {PERFORMANCE_MONITOR && <PerformanceMonitorCollector />}
-        </Canvas>
-        {/* パフォーマンスモニター - 表示（Canvas外） - ローディング完了後のみ表示 */}
-        {PERFORMANCE_MONITOR && !isLoading && <PerformanceMonitorDisplay enabled={PERFORMANCE_MONITOR} />}
-        <UI
-          showHints={!isLoading && uxHints.showHints}
-          showUiHint={!isLoading && uxHints.shouldShowUiHint}
-          showWaterHint={!isLoading && uxHints.shouldShowWaterHint}
-          hintProgress={uxHints.progress}
-          onDismissHints={uxHints.dismissHints}
-          onReopenHints={!isLoading ? uxHints.reopenHints : undefined}
-          onPanelOpened={uxHints.markPanelOpened}
-          onAmbientToggle={uxHints.markAmbientToggled}
+    <div className="App" style={appStyle}>
+      {showLoader && (
+        <Loader
+          progress={loadingProgress}
+          loadingText={loadingText}
+          isExiting={!isLoading}
         />
-        {/* 風向きコンパス - ローディング完了後のみ表示 */}
-        {!isLoading && (
-          <MemoizedWindDirectionDisplay
-            windDirection={windDirection}
-            weather={weather}
-            locationStatus={locationStatus}
-            onRequestPreciseLocation={requestPreciseLocation}
-          />
-        )}
-      </div>
+      )}
+      <SceneCanvas
+        backgroundColor={backgroundColor}
+        isDay={isDay}
+        isLoading={isLoading}
+        isMobile={isMobile}
+        performanceMonitorEnabled={PERFORMANCE_MONITOR}
+        showBottleHint={uxHints.shouldShowBottleHint}
+        weather={weather}
+        windDirection={windDirection}
+        onAssetsLoaded={handleAssetsLoaded}
+        onBottleMessageRead={uxHints.markBottleOpened}
+        onProgress={handleProgress}
+        onWaterInteract={uxHints.markWaterRippled}
+      />
+      {/* パフォーマンスモニター - 表示（Canvas外） - ローディング完了後のみ表示 */}
+      {PERFORMANCE_MONITOR && !isLoading && <PerformanceMonitorDisplay enabled={PERFORMANCE_MONITOR} />}
+      <UI
+        showHints={!isLoading && uxHints.showHints}
+        showUiHint={!isLoading && uxHints.shouldShowUiHint}
+        showWaterHint={!isLoading && uxHints.shouldShowWaterHint}
+        hintProgress={uxHints.progress}
+        onDismissHints={uxHints.dismissHints}
+        onReopenHints={!isLoading ? uxHints.reopenHints : undefined}
+        onPanelOpened={uxHints.markPanelOpened}
+        onAmbientToggle={uxHints.markAmbientToggled}
+      />
+      {/* 風向きコンパス - ローディング完了後のみ表示 */}
+      {!isLoading && (
+        <MemoizedWindDirectionDisplay
+          windDirection={windDirection}
+          weather={weather}
+          locationStatus={locationStatus}
+          onRequestPreciseLocation={requestPreciseLocation}
+        />
+      )}
+    </div>
   );
 };
 

--- a/src/components/SceneCanvas.tsx
+++ b/src/components/SceneCanvas.tsx
@@ -1,0 +1,214 @@
+import React, { Suspense, memo, useEffect, useMemo, useRef } from "react";
+import { Canvas } from "@react-three/fiber";
+import { OrbitControls, useProgress } from "@react-three/drei";
+import * as THREE from "three";
+import FishManager from "./FishManager";
+import ParticleLayerInstanced from "./ParticleLayerInstanced";
+import Clouds from "./Clouds";
+import WeatherAtmosphere from "./WeatherAtmosphere";
+import Ground from "./Ground";
+import Stars from "./Stars";
+import ShootingStars from "./ShootingStars";
+import ReflectedStars from "./ReflectedStars";
+import WaterSurface from "./WaterSurface";
+import LightingController from "./LightingController";
+import SundialGnomon from "./SundialGnomon";
+import SundialBase from "./SundialBase";
+import { DriftingBottle } from "./DriftingBottle";
+import { Sun } from "./Sun";
+import { SceneLights } from "./SceneLights";
+import { SeasonalEffects } from "./SeasonalEffects";
+import { PerformanceMonitorCollector } from "./PerformanceMonitor";
+import { SIMULATED_SECONDS_PER_REAL_SECOND } from "@/constants/core";
+import type { WindDirection } from "@/utils/bottleJournal";
+import type { WeatherSnapshot } from "@/utils/weather";
+
+const WaterPlantsLarge = React.lazy(() => import("./WaterPlantsLarge"));
+const PottedPlant = React.lazy(() => import("./PottedPlant"));
+const Rocks = React.lazy(() => import("./Rocks"));
+const BubbleEffect = React.lazy(() => import("./BubbleEffect"));
+
+const MemoizedGround = memo(Ground);
+const MemoizedFishManager = memo(FishManager);
+const MemoizedParticleLayerInstanced = memo(ParticleLayerInstanced);
+const MemoizedClouds = memo(Clouds);
+const MemoizedStars = memo(Stars);
+const MemoizedShootingStars = memo(ShootingStars);
+const MemoizedReflectedStars = memo(ReflectedStars);
+const MemoizedWaterSurface = memo(WaterSurface);
+const MemoizedSundialGnomon = memo(SundialGnomon);
+const MemoizedSundialBase = memo(SundialBase);
+const MemoizedDriftingBottle = memo(DriftingBottle);
+const MemoizedSeasonalEffects = memo(SeasonalEffects);
+
+interface LoadingTrackerProps {
+  onLoaded: () => void;
+  onProgress: (progress: number, loadingText: string) => void;
+}
+
+/**
+ * Canvas内でThree.jsの読み込み状況を監視し、完了時に親へ通知
+ */
+const LoadingTracker = ({ onLoaded, onProgress }: LoadingTrackerProps) => {
+  const { active, progress, loaded, total } = useProgress();
+
+  useEffect(() => {
+    if (active) {
+      const percentComplete = (loaded / total) * 100;
+      const text = `3Dモデルを読み込み中... (${loaded}/${total})`;
+      onProgress(percentComplete, text);
+    } else {
+      onProgress(100, "完了");
+      onLoaded();
+    }
+  }, [active, progress, loaded, total, onLoaded, onProgress]);
+
+  return null;
+};
+
+interface SceneCanvasProps {
+  backgroundColor: string;
+  isDay: boolean;
+  isLoading: boolean;
+  isMobile: boolean;
+  performanceMonitorEnabled: boolean;
+  showBottleHint: boolean;
+  weather: WeatherSnapshot;
+  windDirection: WindDirection;
+  onAssetsLoaded: () => void;
+  onBottleMessageRead: () => void;
+  onProgress: (progress: number, loadingText: string) => void;
+  onWaterInteract: () => void;
+}
+
+const SceneCanvas = ({
+  backgroundColor,
+  isDay,
+  isLoading,
+  isMobile,
+  performanceMonitorEnabled,
+  showBottleHint,
+  weather,
+  windDirection,
+  onAssetsLoaded,
+  onBottleMessageRead,
+  onProgress,
+  onWaterInteract,
+}: SceneCanvasProps) => {
+  const directionalLightRef = useRef<THREE.DirectionalLight | null>(null);
+  const ambientLightRef = useRef<THREE.AmbientLight | null>(null);
+  const pointLightRef = useRef<THREE.PointLight | null>(null);
+  const spotLightRef = useRef<THREE.SpotLight | null>(null);
+
+  const cameraConfig = useMemo<{ position: [number, number, number]; fov: number }>(
+    () => ({
+      position: [5, 3, 0],
+      fov: isMobile ? 75 : 70,
+    }),
+    [isMobile]
+  );
+  const rendererConfig = useMemo<THREE.WebGLRendererParameters>(
+    () => ({
+      antialias: !isMobile,
+      powerPreference: "high-performance",
+      alpha: false,
+      stencil: false,
+    }),
+    [isMobile]
+  );
+  const canvasDpr = useMemo<[number, number]>(
+    () => (isMobile ? [0.75, 1.25] : [1, 1.75]),
+    [isMobile]
+  );
+
+  return (
+    <Canvas
+      className="App-canvas"
+      camera={cameraConfig}
+      gl={rendererConfig}
+      dpr={canvasDpr}
+      frameloop="always"
+      performance={{ min: 0.5 }}
+    >
+      <LoadingTracker onLoaded={onAssetsLoaded} onProgress={onProgress} />
+      {!isDay && (
+        <>
+          <MemoizedStars />
+          <MemoizedShootingStars />
+          <MemoizedReflectedStars />
+        </>
+      )}
+
+      <color attach="background" args={[backgroundColor]} />
+      <WeatherAtmosphere
+        backgroundColor={backgroundColor}
+        isDay={isDay}
+        weather={weather}
+      />
+
+      <SceneLights
+        directionalLightRef={directionalLightRef}
+        ambientLightRef={ambientLightRef}
+        pointLightRef={pointLightRef}
+        spotLightRef={spotLightRef}
+      />
+      <LightingController
+        directionalLightRef={directionalLightRef}
+        ambientLightRef={ambientLightRef}
+        pointLightRef={pointLightRef}
+        spotLightRef={spotLightRef}
+        weather={weather}
+      />
+
+      <Sun />
+      <OrbitControls
+        enableZoom
+        enablePan
+        enableRotate
+        maxDistance={20}
+        minDistance={1}
+        dampingFactor={0.1}
+        enableDamping
+      />
+
+      <MemoizedGround />
+      <MemoizedWaterSurface weather={weather} onInteract={onWaterInteract} />
+      <MemoizedSundialGnomon />
+      <MemoizedSundialBase />
+
+      <Suspense fallback={null}>
+        <MemoizedFishManager weather={weather} />
+      </Suspense>
+      <Suspense fallback={null}>
+        <WaterPlantsLarge />
+        <PottedPlant />
+        <Rocks />
+        <BubbleEffect />
+      </Suspense>
+      <Suspense fallback={null}>
+        <MemoizedDriftingBottle
+          position={[-3, 8.2, 2]}
+          onMessageRead={onBottleMessageRead}
+          showHint={!isLoading && showBottleHint}
+          windDirection={windDirection}
+          weather={weather}
+        />
+      </Suspense>
+      <Suspense fallback={null}>
+        <MemoizedParticleLayerInstanced />
+        <MemoizedClouds
+          weather={weather}
+          timeScale={SIMULATED_SECONDS_PER_REAL_SECOND / 60}
+        />
+      </Suspense>
+
+      <Suspense fallback={null}>
+        <MemoizedSeasonalEffects weather={weather} />
+      </Suspense>
+
+      {performanceMonitorEnabled && <PerformanceMonitorCollector />}
+    </Canvas>
+  );
+};
+
+export default memo(SceneCanvas);


### PR DESCRIPTION
## 概要
- Canvas 内のシーン構成を App.tsx から SceneCanvas へ分離
- App.tsx をアプリ状態、ローディング、UI オーバーレイ中心の責務へ整理
- シーン内の lazy load、Three.js refs、PerformanceMonitorCollector を SceneCanvas 側へ移動

## 変更内容
- src/components/SceneCanvas.tsx を追加
- App.tsx から Canvas 構成、ライト ref、シーンオブジェクト配置を移動
- App.tsx の行数を削減し、シーンと UI の責務境界を明確化

## テスト計画
- [x] 型チェック通過
- [x] Lint通過
- [x] ビルド成功

🤖 Generated with [Codex CLI](https://openai.com/codex)