### PR TITLE
feature: 便りに水辺へ残る効き目を追加

### DIFF
--- a/src/components/DriftingBottle/MessageCard.tsx
+++ b/src/components/DriftingBottle/MessageCard.tsx
@@ -1,7 +1,11 @@
-import { memo } from "react";
+import { memo, type CSSProperties } from "react";
 import { Html } from "@react-three/drei";
 import { useThree } from "@react-three/fiber";
-import { formatJournalDate, getBottleDiscoveryLabel } from "@/utils/bottleJournal";
+import {
+  formatJournalDate,
+  getBottleDiscoveryLabel,
+  type BottleOmen,
+} from "@/utils/bottleJournal";
 
 /** メッセージカードのプロパティ */
 interface MessageCardProps {
@@ -11,6 +15,8 @@ interface MessageCardProps {
   sender: string;
   /** 表示中の便りの日付 */
   currentDate: string;
+  /** 便りを閉じた後に水辺へ残る小さな効き目 */
+  omen: BottleOmen;
   /** 閉じるボタンのクリックハンドラ */
   onClose: () => void;
 }
@@ -26,7 +32,7 @@ const stopCardEvent = (event: CardPointerEvent) => {
 };
 
 /** カードのスタイル定義 */
-const CARD_STYLES = {
+const CARD_STYLES: Record<string, CSSProperties> = {
   container: {
     background:
       "linear-gradient(150deg, rgba(252, 239, 220, 0.98), rgba(238, 216, 186, 0.98))",
@@ -35,25 +41,25 @@ const CARD_STYLES = {
     width: "330px",
     maxWidth: "calc(100vw - 32px)",
     maxHeight: "min(74vh, 560px)",
-    boxSizing: "border-box" as const,
+    boxSizing: "border-box",
     boxShadow:
       "0 18px 42px rgba(20, 12, 4, 0.36), inset 0 1px 0 rgba(255, 255, 255, 0.6)",
     fontFamily: "'Noto Serif JP', serif",
-    position: "relative" as const,
+    position: "relative",
     border: "2px solid #d4a574",
-    overflow: "hidden" as const,
+    overflow: "hidden",
     display: "flex",
-    flexDirection: "column" as const,
+    flexDirection: "column",
     color: "#4f422f",
-    userSelect: "none" as const,
+    userSelect: "none",
   },
   content: {
-    overflowY: "auto" as const,
+    overflowY: "auto",
     paddingRight: "4px",
-    overscrollBehavior: "contain" as const,
+    overscrollBehavior: "contain",
   },
   closeButton: {
-    position: "absolute" as const,
+    position: "absolute",
     top: "10px",
     right: "10px",
     background: "transparent",
@@ -69,8 +75,8 @@ const CARD_STYLES = {
     padding: "0",
     lineHeight: "1",
     zIndex: 2,
-    pointerEvents: "auto" as const,
-    touchAction: "manipulation" as const,
+    pointerEvents: "auto",
+    touchAction: "manipulation",
   },
   title: {
     margin: "0",
@@ -80,7 +86,7 @@ const CARD_STYLES = {
     letterSpacing: "0.08em",
   },
   header: {
-    position: "relative" as const,
+    position: "relative",
     marginBottom: "14px",
     padding: "0 42px 13px 0",
     borderBottom: "1px solid rgba(160, 112, 64, 0.44)",
@@ -93,7 +99,7 @@ const CARD_STYLES = {
   },
   statusRow: {
     display: "flex",
-    flexWrap: "wrap" as const,
+    flexWrap: "wrap",
     gap: "7px",
     marginBottom: "16px",
   },
@@ -111,14 +117,50 @@ const CARD_STYLES = {
     lineHeight: "1.9",
     color: "#4a4a4a",
     fontSize: "14.5px",
-    whiteSpace: "pre-wrap" as const,
+    whiteSpace: "pre-wrap",
+  },
+  omenBox: {
+    margin: "16px 0 0",
+    padding: "12px 13px",
+    borderRadius: "10px",
+    background: "rgba(255, 250, 239, 0.72)",
+    border: "1px solid rgba(178, 128, 75, 0.28)",
+    boxShadow: "inset 0 1px 0 rgba(255, 255, 255, 0.55)",
+  },
+  omenHeader: {
+    display: "flex",
+    alignItems: "center",
+    gap: "8px",
+    marginBottom: "7px",
+    color: "#6d5132",
+    fontSize: "12px",
+    letterSpacing: "0.12em",
+  },
+  omenDot: {
+    width: "9px",
+    height: "9px",
+    borderRadius: "999px",
+    boxShadow: "0 0 10px currentColor",
+    flexShrink: 0,
+  },
+  omenText: {
+    margin: "0",
+    color: "#5d4e37",
+    fontSize: "12px",
+    lineHeight: "1.7",
+  },
+  omenWorldNote: {
+    margin: "7px 0 0",
+    color: "#8b7355",
+    fontSize: "11px",
+    lineHeight: "1.6",
   },
   sender: {
     marginTop: "15px",
-    textAlign: "right" as const,
+    textAlign: "right",
     fontSize: "12px",
     color: "#8b7355",
-    fontStyle: "italic" as const,
+    fontStyle: "italic",
   },
   footerNote: {
     margin: "18px 0 0 0",
@@ -127,7 +169,7 @@ const CARD_STYLES = {
     color: "#8b7355",
     fontSize: "11px",
     lineHeight: "1.6",
-    textAlign: "center" as const,
+    textAlign: "center",
   },
 };
 
@@ -139,6 +181,7 @@ export const MessageCard = memo(({
   message,
   sender,
   currentDate,
+  omen,
   onClose,
 }: MessageCardProps) => {
   const discoveryLabel = getBottleDiscoveryLabel(currentDate);
@@ -183,8 +226,22 @@ export const MessageCard = memo(({
           </div>
           <p style={CARD_STYLES.message}>{message}</p>
           <div style={CARD_STYLES.sender}>— {sender}</div>
+          <div style={CARD_STYLES.omenBox}>
+            <div style={CARD_STYLES.omenHeader}>
+              <span
+                style={{
+                  ...CARD_STYLES.omenDot,
+                  color: omen.color,
+                  background: omen.color,
+                }}
+              />
+              <span>今日の効き目: {omen.label}</span>
+            </div>
+            <p style={CARD_STYLES.omenText}>{omen.description}</p>
+            <p style={CARD_STYLES.omenWorldNote}>{omen.worldNote}</p>
+          </div>
           <p style={CARD_STYLES.footerNote}>
-            閉じると、今日のしるしが水面に残ります。
+            閉じると、今日の効き目が水面に残ります。
           </p>
         </div>
       </div>

--- a/src/components/DriftingBottle/index.tsx
+++ b/src/components/DriftingBottle/index.tsx
@@ -10,6 +10,7 @@ import { getTimeOfDay } from "@/utils/time";
 import {
   createDailyLifeLog,
   getBottleDiscoveryLabel,
+  getDailyBottleOmen,
   getLocalDateKey,
   loadBottleJournal,
   loadBottleMemorySigns,
@@ -24,21 +25,27 @@ import { BottleModel } from "./BottleModel";
 import { MessageCard } from "./MessageCard";
 
 interface BottleReadAfterglowProps {
+  color: string;
   onComplete: () => void;
 }
 
 const AFTERGLOW_LIFETIME = 3.2;
 
-const afterglowSeeds = [
+const afterglowSeeds: readonly {
+  angle: number;
+  radius: number;
+  speed: number;
+  size: number;
+}[] = [
   { angle: 0.1, radius: 0.34, speed: 0.82, size: 0.034 },
   { angle: 1.35, radius: 0.48, speed: 0.68, size: 0.026 },
   { angle: 2.4, radius: 0.42, speed: 0.75, size: 0.03 },
   { angle: 3.55, radius: 0.54, speed: 0.61, size: 0.024 },
   { angle: 4.7, radius: 0.38, speed: 0.88, size: 0.028 },
   { angle: 5.62, radius: 0.5, speed: 0.7, size: 0.022 },
-] as const;
+];
 
-const BottleReadAfterglow = ({ onComplete }: BottleReadAfterglowProps) => {
+const BottleReadAfterglow = ({ color, onComplete }: BottleReadAfterglowProps) => {
   const groupRef = useRef<THREE.Group>(null);
   const ringMaterialRef = useMemo(
     () =>
@@ -86,6 +93,12 @@ const BottleReadAfterglow = ({ onComplete }: BottleReadAfterglowProps) => {
       sparkleMaterialRef.dispose();
     };
   }, [coreMaterialRef, ringMaterialRef, sparkleMaterialRef]);
+
+  useEffect(() => {
+    ringMaterialRef.color.set(color);
+    coreMaterialRef.color.set(color);
+    sparkleMaterialRef.color.set(color);
+  }, [color, coreMaterialRef, ringMaterialRef, sparkleMaterialRef]);
 
   useFrame((state) => {
     if (!groupRef.current) {
@@ -165,18 +178,6 @@ const getSignPlacement = (date: string, index: number) => {
 
 const BottleMemoryMarks = ({ signs }: BottleMemoryMarksProps) => {
   const groupRef = useRef<THREE.Group>(null);
-  const markMaterial = useMemo(
-    () =>
-      new THREE.MeshBasicMaterial({
-        color: "#fff2a8",
-        transparent: true,
-        opacity: 0.62,
-        depthWrite: false,
-        depthTest: false,
-        blending: THREE.AdditiveBlending,
-      }),
-    []
-  );
   const ringMaterial = useMemo(
     () =>
       new THREE.MeshBasicMaterial({
@@ -192,10 +193,9 @@ const BottleMemoryMarks = ({ signs }: BottleMemoryMarksProps) => {
 
   useEffect(() => {
     return () => {
-      markMaterial.dispose();
       ringMaterial.dispose();
     };
-  }, [markMaterial, ringMaterial]);
+  }, [ringMaterial]);
 
   useFrame((state) => {
     if (!groupRef.current || signs.length === 0) {
@@ -204,7 +204,6 @@ const BottleMemoryMarks = ({ signs }: BottleMemoryMarksProps) => {
 
     const time = state.clock.getElapsedTime();
     groupRef.current.rotation.y = Math.sin(time * 0.16) * 0.08;
-    markMaterial.opacity = 0.52 + Math.sin(time * 1.4) * 0.08;
     ringMaterial.opacity = 0.24 + Math.sin(time * 0.9) * 0.05;
   });
 
@@ -219,12 +218,20 @@ const BottleMemoryMarks = ({ signs }: BottleMemoryMarksProps) => {
         const x = Math.cos(placement.angle) * placement.radius;
         const z = Math.sin(placement.angle) * placement.radius;
         const scale = placement.size * (1 - index * 0.045);
+        const signColor = sign.omen?.color ?? "#fff2a8";
 
         return (
           <group key={sign.date} position={[x, 0.01 + index * 0.004, z]}>
             <mesh rotation={[-Math.PI / 2, 0, placement.angle]} scale={[scale, scale * 1.55, 1]}>
               <circleGeometry args={[1, 16]} />
-              <primitive object={markMaterial} attach="material" />
+              <meshBasicMaterial
+                color={signColor}
+                transparent={true}
+                opacity={0.58}
+                depthWrite={false}
+                depthTest={false}
+                blending={THREE.AdditiveBlending}
+              />
             </mesh>
             <mesh rotation={[-Math.PI / 2, 0, 0]} scale={[scale * 4.4, scale * 4.4, 1]}>
               <ringGeometry args={[0.82, 1, 40]} />
@@ -293,6 +300,17 @@ export const DriftingBottle = ({
       }),
     [realTime.hours, season, today, weather, windDirection]
   );
+  const bottleOmen = useMemo(
+    () =>
+      getDailyBottleOmen({
+        date: today,
+        season,
+        timeOfDay: getTimeOfDay(realTime.hours),
+        windDirection,
+        weather,
+      }),
+    [realTime.hours, season, today, weather, windDirection]
+  );
 
   // 1日1回、Gemini経由でメッセージを取得
   useEffect(() => {
@@ -333,10 +351,11 @@ export const DriftingBottle = ({
       message: currentMessage,
       sender: currentSender,
       lifeLog: displayedLifeLog,
+      omen: bottleOmen,
       readAt: new Date().toISOString(),
     });
     setJournalEntries(nextJournal);
-  }, [currentMessage, currentSender, displayedLifeLog, showMessage, today]);
+  }, [bottleOmen, currentMessage, currentSender, displayedLifeLog, showMessage, today]);
 
   const handleCloseMessage = () => {
     setShowMessage(false);
@@ -344,6 +363,7 @@ export const DriftingBottle = ({
       saveBottleMemorySign({
         date: today,
         label: getBottleDiscoveryLabel(today),
+        omen: bottleOmen,
         readAt: new Date().toISOString(),
       })
     );
@@ -387,12 +407,14 @@ export const DriftingBottle = ({
           message={currentMessage}
           sender={currentSender}
           currentDate={today}
+          omen={bottleOmen}
           onClose={handleCloseMessage}
         />
       )}
       {readAfterglowId > 0 && (
         <BottleReadAfterglow
           key={readAfterglowId}
+          color={bottleOmen.color}
           onComplete={() => setReadAfterglowId(0)}
         />
       )}

--- a/src/utils/bottleJournal.ts
+++ b/src/utils/bottleJournal.ts
@@ -9,13 +9,30 @@ export interface BottleJournalEntry {
   message: string;
   sender: string;
   lifeLog: string;
+  omen?: BottleOmen;
   readAt: string;
 }
 
 export interface BottleMemorySign {
   date: string;
   label: string;
+  omen?: BottleOmen;
   readAt: string;
+}
+
+export type BottleOmenId =
+  | "fish-gather"
+  | "quiet-ripples"
+  | "firefly-glow"
+  | "deep-current"
+  | "hidden-shore";
+
+export interface BottleOmen {
+  id: BottleOmenId;
+  label: string;
+  description: string;
+  worldNote: string;
+  color: string;
 }
 
 interface LifeLogInput {
@@ -89,14 +106,52 @@ const weatherNotes: Record<WeatherSnapshot["condition"], readonly string[]> = {
     "遠い空が光り、少し遅れて水辺へ響いた",
     "雷の気配に合わせて、水面の影が一瞬揺れた",
   ],
-} as const;
+};
 
 const discoveryLabels = [
   "波紋の発見",
   "風向きのしるし",
   "光の漂着",
   "水面の記録",
-] as const;
+] satisfies readonly string[];
+
+const bottleOmens: readonly BottleOmen[] = [
+  {
+    id: "fish-gather",
+    label: "魚寄せ",
+    description: "しばらく魚影が瓶の近くを横切りやすくなる。",
+    worldNote: "瓶の周りに、魚が通ったあとの淡いしるしが残る。",
+    color: "#b8f1ff",
+  },
+  {
+    id: "quiet-ripples",
+    label: "静かな波紋",
+    description: "水面を触れたときの光が少し細く、長く残る。",
+    worldNote: "水面に細い輪が残り、次の波を待っている。",
+    color: "#f7f0c2",
+  },
+  {
+    id: "firefly-glow",
+    label: "蛍火",
+    description: "夜の水辺に、小さな光の粒が集まりやすくなる。",
+    worldNote: "瓶の口元に、蛍のような点がゆっくり回る。",
+    color: "#d6ff9f",
+  },
+  {
+    id: "deep-current",
+    label: "底流",
+    description: "深いところの流れが少し強まり、影がゆっくり動く。",
+    worldNote: "底から上がる青い粒が、短いあいだ水面へ向かう。",
+    color: "#9fd7ff",
+  },
+  {
+    id: "hidden-shore",
+    label: "隠れ岸",
+    description: "石や葉の影が濃くなり、見落としやすい場所が少し目立つ。",
+    worldNote: "岸辺の影に、古い地図の端のような光が残る。",
+    color: "#ffd5a3",
+  },
+] satisfies readonly BottleOmen[];
 
 const seasonNotes: Record<Season, string[]> = {
   spring: [
@@ -153,6 +208,19 @@ const pick = <T,>(items: readonly T[], seed: number) => items[seed % items.lengt
 
 export const getBottleDiscoveryLabel = (date: string) =>
   pick(discoveryLabels, createSeed(date));
+
+export const getDailyBottleOmen = ({
+  date,
+  season,
+  timeOfDay,
+  windDirection,
+  weather,
+}: LifeLogInput): BottleOmen => {
+  const seed = createSeed(
+    `omen:${date}:${season}:${timeOfDay}:${windDirection}:${weather.condition}:${weather.trend}`
+  );
+  return pick(bottleOmens, seed);
+};
 
 export const getLocalDateKey = (date = new Date()) => {
   const year = date.getFullYear();
@@ -219,6 +287,7 @@ export const loadBottleJournal = (): BottleJournalEntry[] => {
         typeof entry?.message === "string" &&
         typeof entry?.sender === "string" &&
         typeof entry?.lifeLog === "string" &&
+        (entry.omen === undefined || isBottleOmen(entry.omen)) &&
         typeof entry?.readAt === "string"
     );
   } catch (error) {
@@ -263,12 +332,32 @@ export const loadBottleMemorySigns = (): BottleMemorySign[] => {
       (sign): sign is BottleMemorySign =>
         typeof sign?.date === "string" &&
         typeof sign?.label === "string" &&
+        (sign.omen === undefined || isBottleOmen(sign.omen)) &&
         typeof sign?.readAt === "string"
     );
   } catch (error) {
     console.error("Error loading bottle memory signs:", error);
     return [];
   }
+};
+
+const isBottleOmen = (value: unknown): value is BottleOmen => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  return (
+    "id" in value &&
+    "label" in value &&
+    "description" in value &&
+    "worldNote" in value &&
+    "color" in value &&
+    typeof value.id === "string" &&
+    typeof value.label === "string" &&
+    typeof value.description === "string" &&
+    typeof value.worldNote === "string" &&
+    typeof value.color === "string"
+  );
 };
 
 export const saveBottleMemorySign = (sign: BottleMemorySign) => {


### PR DESCRIPTION
## 概要
- 漂流瓶の便りに「今日の効き目」を追加
- 便りを閉じた後のしるしへ効き目情報を保存し、水辺に残る変化を強化
- 既存の保存データと互換性を保ちながら、効き目ごとの色と説明を表示

## 変更内容
- `BottleOmen` と日替わり効き目生成を追加
- メッセージカードに効き目名・説明・水辺に残る変化を表示
- 読後の光と記憶のしるしを効き目カラーに対応
- 型アサーションを使わずにlocalStorageデータを検証

## テスト計画
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`

🤖 Generated with [Codex CLI](https://openai.com/codex)