### PR TITLE
fix: シーンモデルを事前読み込みする

### DIFF
--- a/src/components/SceneCanvas.tsx
+++ b/src/components/SceneCanvas.tsx
@@ -20,8 +20,12 @@ import { SceneLights } from "./SceneLights";
 import { SeasonalEffects } from "./SeasonalEffects";
 import { PerformanceMonitorCollector } from "./PerformanceMonitor";
 import { SIMULATED_SECONDS_PER_REAL_SECOND } from "@/constants/core";
+import { preloadModel } from "@/hooks/useModelScene";
 import type { WindDirection } from "@/utils/bottleJournal";
 import type { WeatherSnapshot } from "@/utils/weather";
+
+const PRELOADED_MODEL_KEYS = ["flatfish", "leaf", "lily", "pottedPlant", "frog"] as const;
+PRELOADED_MODEL_KEYS.forEach(preloadModel);
 
 const WaterPlantsLarge = React.lazy(() => import("./WaterPlantsLarge"));
 const PottedPlant = React.lazy(() => import("./PottedPlant"));


### PR DESCRIPTION
## 概要
- GLTFモデルをCanvas描画前に事前読み込みするように変更
- Frog描画中にモデルロード進捗が更新され、React warning が出る経路を抑制
- シーン内で使う主要モデルを `preloadModel` で先に登録

## 変更内容
- `SceneCanvas` のmodule初期化時に `flatfish` / `leaf` / `lily` / `pottedPlant` / `frog` をpreload
- `useModelScene` の既存preload APIを利用し、描画コンポーネント側の変更はなし

## テスト計画
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 実ブラウザでFrog/LoadingTrackerのReact warningが出ないことを確認

🤖 Generated with [Codex CLI](https://openai.com/codex)