### PR TITLE
improve: カエル反応リングの奥行きを自然にする

### DIFF
--- a/src/components/Frog.tsx
+++ b/src/components/Frog.tsx
@@ -300,7 +300,7 @@ const Frog: React.FC<FrogProps> = ({
           color="#f1ffd1"
           transparent
           opacity={0}
-          depthTest={false}
+          depthTest={true}
           depthWrite={false}
         />
       </mesh>
@@ -310,7 +310,7 @@ const Frog: React.FC<FrogProps> = ({
           color="#9ffff2"
           transparent
           opacity={0}
-          depthTest={false}
+          depthTest={true}
           depthWrite={false}
         />
       </mesh>


### PR DESCRIPTION
## 概要
- カエルクリック時の反応リングが常に前面へ出ないように調整
- 水面/周辺オブジェクトとの奥行き関係を守り、輪っか演出の違和感を抑える

## テスト計画
- [x] npx tsc --noEmit
- [x] npm run lint
- [x] npm run build
- [x] git diff --check

🤖 Generated with [Codex CLI](https://openai.com/codex)