### PR TITLE
improve: 漂流瓶のクリック範囲を広げる

### DIFF
--- a/src/components/DriftingBottle/index.tsx
+++ b/src/components/DriftingBottle/index.tsx
@@ -342,6 +342,11 @@ export const DriftingBottle = ({
       onPointerOver={() => setHovered(true)}
       onPointerOut={() => setHovered(false)}
     >
+      {/* 見た目は変えず、漂流瓶を少し雑に押しても反応するようにする */}
+      <mesh position={[0, 0.1, 0]} scale={[0.72, 1.18, 0.72]}>
+        <sphereGeometry args={[1, 16, 12]} />
+        <meshBasicMaterial transparent opacity={0} depthWrite={false} />
+      </mesh>
       <BottleModel hovered={hovered} />
       <BottleMemoryMarks signs={memorySigns} />
       {showHint && !showMessage && (


### PR DESCRIPTION
## 概要
- 漂流瓶に透明なクリック用メッシュを追加
- 見た目を変えずに、少し外側を押しても便りを開けるように調整

## 変更内容
- `DriftingBottle` のクリック対象内に opacity 0 の球メッシュを追加
- `visible={false}` は使わず、raycast 対象として残る透明materialで当たり判定を拡張

## テスト計画
- [x] npx tsc --noEmit
- [x] npm run lint
- [x] npm run build
- [x] git diff --check
- [ ] 実ブラウザで瓶クリック確認

🤖 Generated with [Codex CLI](https://openai.com/codex)
