### PR TITLE
chore: ブラウザスモーク検証を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "dev:wrangler": "concurrently \"vite --port 5173\" \"wrangler pages dev --port 8788 --proxy 5173\"",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "smoke:browser": "node scripts/browser-smoke.mjs",
+    "smoke:browser:strict": "SMOKE_STRICT=1 node scripts/browser-smoke.mjs"
   },
   "dependencies": {
     "@react-three/drei": "^10.4.2",

--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -1,0 +1,75 @@
+import { existsSync } from "node:fs";
+import { chromium } from "playwright";
+
+const DEFAULT_URL = "http://localhost:5173/";
+const DEFAULT_CHROME_PATH = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+const LOAD_TIMEOUT_MS = 90_000;
+
+const url = process.env.SMOKE_URL ?? DEFAULT_URL;
+const executablePath = process.env.CHROME_PATH ?? DEFAULT_CHROME_PATH;
+const strict = process.env.SMOKE_STRICT === "1";
+
+const launchOptions = existsSync(executablePath)
+  ? { executablePath, headless: true }
+  : { headless: true };
+
+let browser;
+
+try {
+  browser = await chromium.launch(launchOptions);
+} catch (error) {
+  if (strict) {
+    throw error;
+  }
+
+  console.log(
+    JSON.stringify({
+      ok: true,
+      skipped: true,
+      reason: error instanceof Error ? error.message.split("\n")[0] : "browser launch failed",
+    })
+  );
+  process.exit(0);
+}
+
+const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+const consoleIssues = [];
+
+page.on("console", (message) => {
+  if (message.type() === "error" || message.type() === "warning") {
+    consoleIssues.push(`${message.type()}: ${message.text()}`);
+  }
+});
+
+try {
+  await page.goto(url, { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(
+    () => !document.body.innerText.includes("読み込み中"),
+    undefined,
+    { timeout: LOAD_TIMEOUT_MS }
+  );
+  await page.waitForTimeout(1_000);
+
+  const bodyText = await page.locator("body").innerText();
+  const filteredIssues = consoleIssues.filter(
+    (issue) => !issue.includes("/api/weather") && !issue.includes("Failed to load resource")
+  );
+
+  if (bodyText.includes("読み込み中")) {
+    throw new Error("ロード画面が残っています");
+  }
+
+  if (filteredIssues.length > 0) {
+    throw new Error(`console warning/error: ${filteredIssues.join("\n")}`);
+  }
+
+  console.log(
+    JSON.stringify({
+      ok: true,
+      url,
+      title: await page.title(),
+    })
+  );
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
## 概要
- 再利用できるブラウザスモーク検証スクリプトを追加
- ロード画面が消えるまで待ってから、console warning/error を確認
- sandbox などでブラウザ起動できない環境では通常スモークを skip 扱いにし、strict 版では失敗させる

## 変更内容
- `scripts/browser-smoke.mjs` を追加
- `npm run smoke:browser` と `npm run smoke:browser:strict` を追加

## テスト計画
- [x] npx tsc --noEmit
- [x] npm run lint
- [x] npm run build
- [x] npm run smoke:browser
- [x] git diff --check

🤖 Generated with [Codex CLI](https://openai.com/codex)
