### PR TITLE
improve: 魚に背側の受光ハイライトを加える

### DIFF
--- a/src/components/FishManager.tsx
+++ b/src/components/FishManager.tsx
@@ -25,16 +25,20 @@ import {
 } from "@/fish/materials";
 import { updateFishMovement } from "@/fish/movement";
 import {
+  FISH_DORSAL_SHEEN_COLOR,
+  FISH_DORSAL_SHEEN_ROTATION,
   FISH_EYE_COLOR,
   FISH_EYE_HIGHLIGHT_COLOR,
   FISH_UNDERBODY_SHADOW_COLOR,
   FISH_UNDERBODY_SHADOW_ROTATION,
+  FLATFISH_DORSAL_SHEEN_POSITION,
   FLATFISH_EYE_POSITIONS,
   FLATFISH_MARK_POSITION,
   FLATFISH_MARK_ROTATION,
   FLATFISH_UNDERBODY_SHADOW_POSITION,
   getFishAccentBaseGlow,
   getFishAccentBaseOpacity,
+  NORMAL_FISH_DORSAL_SHEEN_POSITION,
   NORMAL_FISH_EYE_POSITIONS,
   NORMAL_FISH_MARK_POSITION,
   NORMAL_FISH_MARK_ROTATION,
@@ -113,6 +117,20 @@ const FishManager: React.FC<FishManagerProps> = ({ weather, waterSignal }) => {
       }),
     []
   );
+  const fishSheenGeometry = useMemo(
+    () => new THREE.CircleGeometry(0.14, 10),
+    []
+  );
+  const fishSheenMaterial = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        color: FISH_DORSAL_SHEEN_COLOR,
+        transparent: true,
+        opacity: 0.1,
+        depthWrite: false,
+      }),
+    []
+  );
 
   const timeRef = useRef(0);
   const previousWaterSignalRef = useRef(waterSignal);
@@ -168,6 +186,8 @@ const FishManager: React.FC<FishManagerProps> = ({ weather, waterSignal }) => {
       fishEyeHighlightMaterial.dispose();
       fishShadowGeometry.dispose();
       fishShadowMaterial.dispose();
+      fishSheenGeometry.dispose();
+      fishSheenMaterial.dispose();
     };
   }, [
     fishEyeGeometry,
@@ -176,6 +196,8 @@ const FishManager: React.FC<FishManagerProps> = ({ weather, waterSignal }) => {
     fishEyeMaterial,
     fishShadowGeometry,
     fishShadowMaterial,
+    fishSheenGeometry,
+    fishSheenMaterial,
     flatfishAccentGeometry,
     normalAccentGeometry,
   ]);
@@ -272,6 +294,12 @@ const FishManager: React.FC<FishManagerProps> = ({ weather, waterSignal }) => {
         const shadowScale: [number, number, number] = isFlatfish
           ? [fish.size * 0.95, fish.size * 0.34, 1]
           : [fish.size * 0.78, fish.size * 0.22, 1];
+        const sheenPosition = isFlatfish
+          ? FLATFISH_DORSAL_SHEEN_POSITION
+          : NORMAL_FISH_DORSAL_SHEEN_POSITION;
+        const sheenScale: [number, number, number] = isFlatfish
+          ? [fish.size * 0.7, fish.size * 0.28, 1]
+          : [fish.size * 0.58, fish.size * 0.16, 1];
 
         return (
           <group
@@ -302,6 +330,13 @@ const FishManager: React.FC<FishManagerProps> = ({ weather, waterSignal }) => {
               scale={shadowScale}
               geometry={fishShadowGeometry}
               material={fishShadowMaterial}
+            />
+            <mesh
+              position={sheenPosition}
+              rotation={FISH_DORSAL_SHEEN_ROTATION}
+              scale={sheenScale}
+              geometry={fishSheenGeometry}
+              material={fishSheenMaterial}
             />
             <mesh
               position={isFlatfish ? FLATFISH_MARK_POSITION : NORMAL_FISH_MARK_POSITION}

--- a/src/fish/visualDetails.ts
+++ b/src/fish/visualDetails.ts
@@ -21,6 +21,12 @@ export const FISH_UNDERBODY_SHADOW_ROTATION: [number, number, number] = [Math.PI
 export const NORMAL_FISH_UNDERBODY_SHADOW_POSITION: [number, number, number] = [0, -0.13, 0];
 export const FLATFISH_UNDERBODY_SHADOW_POSITION: [number, number, number] = [0, -0.018, 0];
 
+// 背側の受光ハイライト（水中影と対になるカウンターシェーディング）
+export const FISH_DORSAL_SHEEN_COLOR = "#d8f0ff";
+export const FISH_DORSAL_SHEEN_ROTATION: [number, number, number] = [Math.PI / 2, 0, 0];
+export const NORMAL_FISH_DORSAL_SHEEN_POSITION: [number, number, number] = [0, 0.12, 0];
+export const FLATFISH_DORSAL_SHEEN_POSITION: [number, number, number] = [0, 0.016, 0];
+
 export const getFishAccentBaseOpacity = (
   isFlatfish: boolean,
   colorPattern: FishColorPattern


### PR DESCRIPTION
## 概要

水中影 (#187) と対になる **カウンターシェーディング** として、魚の背側に淡い受光ハイライトを追加しました。上（背）が明るく下（腹）が暗い自然な陰影で、魚の立体感と存在感を高めます。

## 変更点

- `src/fish/visualDetails.ts`: 背側ハイライトの色・回転・位置定数を追加（`FISH_DORSAL_SHEEN_*`, `NORMAL_FISH_DORSAL_SHEEN_POSITION`, `FLATFISH_DORSAL_SHEEN_POSITION`）
- `src/components/FishManager.tsx`: 水中影と同じ構造で、共有ジオメトリ/マテリアルの淡いハイライトメッシュを各魚に描画。dispose も追加

## 実装メモ

- `#187` の `FISH_UNDERBODY_SHADOW_*` と対称になる命名・構造に統一
- `depthWrite: false` / 低 opacity で silhouette 内に馴染むよう調整
- 通常魚・ヒラメそれぞれに位置とスケールを用意

## 検証

- `npx tsc --noEmit` ✅
- `npm run lint` ✅
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)