### PR TITLE
improve: 魚の受光ハイライトを天候に連動させる

### DIFF
--- a/src/components/FishManager.tsx
+++ b/src/components/FishManager.tsx
@@ -26,6 +26,8 @@ import {
 import { updateFishMovement } from "@/fish/movement";
 import {
   FISH_DORSAL_SHEEN_COLOR,
+  FISH_DORSAL_SHEEN_OPACITY_MAX,
+  FISH_DORSAL_SHEEN_OPACITY_MIN,
   FISH_DORSAL_SHEEN_ROTATION,
   FISH_EYE_COLOR,
   FISH_EYE_HIGHLIGHT_COLOR,
@@ -38,6 +40,7 @@ import {
   FLATFISH_UNDERBODY_SHADOW_POSITION,
   getFishAccentBaseGlow,
   getFishAccentBaseOpacity,
+  getUnderwaterBrightness,
   NORMAL_FISH_DORSAL_SHEEN_POSITION,
   NORMAL_FISH_EYE_POSITIONS,
   NORMAL_FISH_MARK_POSITION,
@@ -131,6 +134,16 @@ const FishManager: React.FC<FishManagerProps> = ({ weather, waterSignal }) => {
       }),
     []
   );
+
+  // 晴天ほど水中に光が差し、背側の受光ハイライトが強まる
+  useEffect(() => {
+    const underwaterBrightness = getUnderwaterBrightness(rainIntensity, cloudIntensity);
+    fishSheenMaterial.opacity = THREE.MathUtils.lerp(
+      FISH_DORSAL_SHEEN_OPACITY_MIN,
+      FISH_DORSAL_SHEEN_OPACITY_MAX,
+      underwaterBrightness
+    );
+  }, [cloudIntensity, fishSheenMaterial, rainIntensity]);
 
   const timeRef = useRef(0);
   const previousWaterSignalRef = useRef(waterSignal);

--- a/src/fish/visualDetails.ts
+++ b/src/fish/visualDetails.ts
@@ -27,6 +27,16 @@ export const FISH_DORSAL_SHEEN_ROTATION: [number, number, number] = [Math.PI / 2
 export const NORMAL_FISH_DORSAL_SHEEN_POSITION: [number, number, number] = [0, 0.12, 0];
 export const FLATFISH_DORSAL_SHEEN_POSITION: [number, number, number] = [0, 0.016, 0];
 
+// 天候で変わる受光ハイライトの不透明度（曇天/雨天は光が差さず弱まる）
+export const FISH_DORSAL_SHEEN_OPACITY_MIN = 0.05;
+export const FISH_DORSAL_SHEEN_OPACITY_MAX = 0.14;
+
+/** 晴天ほど1に近づく水中の明るさ係数を返す */
+export const getUnderwaterBrightness = (
+  rainIntensity: number,
+  cloudIntensity: number
+) => Math.max(0, 1 - rainIntensity * 0.6 - cloudIntensity * 0.3);
+
 export const getFishAccentBaseOpacity = (
   isFlatfish: boolean,
   colorPattern: FishColorPattern


### PR DESCRIPTION
## 概要

背側の受光ハイライト (#188) の強さを **天候** に連動させました。晴天ほど水中に光が差し込む現実に合わせ、雨天・曇天では弱まり、晴天では強まります。

## 変更点

- `src/fish/visualDetails.ts`: `FISH_DORSAL_SHEEN_OPACITY_MIN/MAX` と `getUnderwaterBrightness()` を追加
- `src/components/FishManager.tsx`: `rainIntensity` / `cloudIntensity` から算出した明るさで sheen マテリアルの opacity を更新（既存の天候値を再利用）

## 検証

- `npx tsc --noEmit` ✅ / `npm run lint` ✅ / `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)