### PR TITLE
improve: 魚の水中影を天候に連動させる

### DIFF
--- a/src/components/FishManager.tsx
+++ b/src/components/FishManager.tsx
@@ -32,6 +32,8 @@ import {
   FISH_EYE_COLOR,
   FISH_EYE_HIGHLIGHT_COLOR,
   FISH_UNDERBODY_SHADOW_COLOR,
+  FISH_UNDERBODY_SHADOW_OPACITY_MAX,
+  FISH_UNDERBODY_SHADOW_OPACITY_MIN,
   FISH_UNDERBODY_SHADOW_ROTATION,
   FLATFISH_DORSAL_SHEEN_POSITION,
   FLATFISH_EYE_POSITIONS,
@@ -135,7 +137,7 @@ const FishManager: React.FC<FishManagerProps> = ({ weather, waterSignal }) => {
     []
   );
 
-  // 晴天ほど水中に光が差し、背側の受光ハイライトが強まる
+  // 晴天ほど水中に光が差し、背側の受光ハイライトが強まり水中影も締まる
   useEffect(() => {
     const underwaterBrightness = getUnderwaterBrightness(rainIntensity, cloudIntensity);
     fishSheenMaterial.opacity = THREE.MathUtils.lerp(
@@ -143,7 +145,12 @@ const FishManager: React.FC<FishManagerProps> = ({ weather, waterSignal }) => {
       FISH_DORSAL_SHEEN_OPACITY_MAX,
       underwaterBrightness
     );
-  }, [cloudIntensity, fishSheenMaterial, rainIntensity]);
+    fishShadowMaterial.opacity = THREE.MathUtils.lerp(
+      FISH_UNDERBODY_SHADOW_OPACITY_MIN,
+      FISH_UNDERBODY_SHADOW_OPACITY_MAX,
+      underwaterBrightness
+    );
+  }, [cloudIntensity, fishShadowMaterial, fishSheenMaterial, rainIntensity]);
 
   const timeRef = useRef(0);
   const previousWaterSignalRef = useRef(waterSignal);

--- a/src/fish/visualDetails.ts
+++ b/src/fish/visualDetails.ts
@@ -21,6 +21,10 @@ export const FISH_UNDERBODY_SHADOW_ROTATION: [number, number, number] = [Math.PI
 export const NORMAL_FISH_UNDERBODY_SHADOW_POSITION: [number, number, number] = [0, -0.13, 0];
 export const FLATFISH_UNDERBODY_SHADOW_POSITION: [number, number, number] = [0, -0.018, 0];
 
+// 天候で変わる水中影の不透明度（晴天は締まり、曇天は拡散して和らぐ）
+export const FISH_UNDERBODY_SHADOW_OPACITY_MIN = 0.1;
+export const FISH_UNDERBODY_SHADOW_OPACITY_MAX = 0.22;
+
 // 背側の受光ハイライト（水中影と対になるカウンターシェーディング）
 export const FISH_DORSAL_SHEEN_COLOR = "#d8f0ff";
 export const FISH_DORSAL_SHEEN_ROTATION: [number, number, number] = [Math.PI / 2, 0, 0];


### PR DESCRIPTION
## 概要

受光ハイライトの天候連動 (#189) と対になるよう、水中影 (#187) の不透明度も同じ光量係数 `getUnderwaterBrightness` で駆動しました。晴天では影が締まり、曇天・雨天では拡散して和らぎます。ハイライトと影が同じ光源条件で連動し、陰影の整合が取れます。

## 変更点

- `src/fish/visualDetails.ts`: `FISH_UNDERBODY_SHADOW_OPACITY_MIN/MAX` を追加
- `src/components/FishManager.tsx`: 既存の天候連動 useEffect に影の opacity 更新を追加

## 検証

- `npx tsc --noEmit` ✅ / `npm run lint` ✅ / `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)