### PR TITLE
improve: 魚の瞳のキャッチライトを天候に連動させる

### DIFF
--- a/src/components/FishManager.tsx
+++ b/src/components/FishManager.tsx
@@ -31,6 +31,8 @@ import {
   FISH_DORSAL_SHEEN_ROTATION,
   FISH_EYE_COLOR,
   FISH_EYE_HIGHLIGHT_COLOR,
+  FISH_EYE_HIGHLIGHT_OPACITY_MAX,
+  FISH_EYE_HIGHLIGHT_OPACITY_MIN,
   FISH_UNDERBODY_SHADOW_COLOR,
   FISH_UNDERBODY_SHADOW_OPACITY_MAX,
   FISH_UNDERBODY_SHADOW_OPACITY_MIN,
@@ -150,7 +152,18 @@ const FishManager: React.FC<FishManagerProps> = ({ weather, waterSignal }) => {
       FISH_UNDERBODY_SHADOW_OPACITY_MAX,
       underwaterBrightness
     );
-  }, [cloudIntensity, fishShadowMaterial, fishSheenMaterial, rainIntensity]);
+    fishEyeHighlightMaterial.opacity = THREE.MathUtils.lerp(
+      FISH_EYE_HIGHLIGHT_OPACITY_MIN,
+      FISH_EYE_HIGHLIGHT_OPACITY_MAX,
+      underwaterBrightness
+    );
+  }, [
+    cloudIntensity,
+    fishEyeHighlightMaterial,
+    fishShadowMaterial,
+    fishSheenMaterial,
+    rainIntensity,
+  ]);
 
   const timeRef = useRef(0);
   const previousWaterSignalRef = useRef(waterSignal);

--- a/src/fish/visualDetails.ts
+++ b/src/fish/visualDetails.ts
@@ -16,6 +16,9 @@ export const FLATFISH_EYE_POSITIONS: [number, number, number][] = [
 
 export const FISH_EYE_COLOR = "#08131b";
 export const FISH_EYE_HIGHLIGHT_COLOR = "#dff7ff";
+// 天候で変わる瞳のキャッチライト不透明度（晴天ほど光を強く受ける）
+export const FISH_EYE_HIGHLIGHT_OPACITY_MIN = 0.5;
+export const FISH_EYE_HIGHLIGHT_OPACITY_MAX = 0.9;
 export const FISH_UNDERBODY_SHADOW_COLOR = "#07141d";
 export const FISH_UNDERBODY_SHADOW_ROTATION: [number, number, number] = [Math.PI / 2, 0, 0];
 export const NORMAL_FISH_UNDERBODY_SHADOW_POSITION: [number, number, number] = [0, -0.13, 0];


### PR DESCRIPTION
## 概要

受光ハイライト (#189) と水中影 (#190) の天候連動に揃え、目のキャッチライト（ハイライト）の不透明度も同じ光量係数 `getUnderwaterBrightness` で駆動しました。晴天ほど瞳が光を強く受け、生気が増します。

## 変更点

- `src/fish/visualDetails.ts`: `FISH_EYE_HIGHLIGHT_OPACITY_MIN/MAX` を追加
- `src/components/FishManager.tsx`: 既存の天候連動 useEffect に目のハイライト opacity 更新を追加

## 検証

- `npx tsc --noEmit` ✅ / `npm run lint` ✅ / `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)