### PR TITLE
refactor: 魚の天候連動opacityをデータ駆動に集約する

### DIFF
--- a/src/components/FishManager.tsx
+++ b/src/components/FishManager.tsx
@@ -139,24 +139,18 @@ const FishManager: React.FC<FishManagerProps> = ({ weather, waterSignal }) => {
     []
   );
 
-  // 晴天ほど水中に光が差し、背側の受光ハイライトが強まり水中影も締まる
+  // 晴天ほど水中に光が差し、背側の受光ハイライト・瞳のキャッチライトが
+  // 強まり、水中影も締まる。3要素を同じ光量係数でまとめて更新する
   useEffect(() => {
     const underwaterBrightness = getUnderwaterBrightness(rainIntensity, cloudIntensity);
-    fishSheenMaterial.opacity = THREE.MathUtils.lerp(
-      FISH_DORSAL_SHEEN_OPACITY_MIN,
-      FISH_DORSAL_SHEEN_OPACITY_MAX,
-      underwaterBrightness
-    );
-    fishShadowMaterial.opacity = THREE.MathUtils.lerp(
-      FISH_UNDERBODY_SHADOW_OPACITY_MIN,
-      FISH_UNDERBODY_SHADOW_OPACITY_MAX,
-      underwaterBrightness
-    );
-    fishEyeHighlightMaterial.opacity = THREE.MathUtils.lerp(
-      FISH_EYE_HIGHLIGHT_OPACITY_MIN,
-      FISH_EYE_HIGHLIGHT_OPACITY_MAX,
-      underwaterBrightness
-    );
+    const weatherOpacityTargets: [THREE.Material, number, number][] = [
+      [fishSheenMaterial, FISH_DORSAL_SHEEN_OPACITY_MIN, FISH_DORSAL_SHEEN_OPACITY_MAX],
+      [fishShadowMaterial, FISH_UNDERBODY_SHADOW_OPACITY_MIN, FISH_UNDERBODY_SHADOW_OPACITY_MAX],
+      [fishEyeHighlightMaterial, FISH_EYE_HIGHLIGHT_OPACITY_MIN, FISH_EYE_HIGHLIGHT_OPACITY_MAX],
+    ];
+    for (const [material, min, max] of weatherOpacityTargets) {
+      material.opacity = THREE.MathUtils.lerp(min, max, underwaterBrightness);
+    }
   }, [
     cloudIntensity,
     fishEyeHighlightMaterial,


### PR DESCRIPTION
## 概要

`#189` `#190` `#192` で追加した天候連動の opacity 更新が、sheen / 水中影 / 瞳のキャッチライトで同型の `lerp` 3連になっていました。`[material, min, max]` のテーブル反復に集約し、要素追加時の見通しを良くします。**挙動は不変**です。

## 変更点

- `src/components/FishManager.tsx`: 天候連動 useEffect を配列反復にリファクタ

## 検証

- `npx tsc --noEmit` ✅ / `npm run lint` ✅ / `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)