### PR TITLE
refactor: カエルのインタラクション定数をconstantsへ集約する

### DIFF
--- a/src/components/Frog.tsx
+++ b/src/components/Frog.tsx
@@ -4,13 +4,18 @@ import * as THREE from "three";
 import { useModelScene } from "../hooks/useModelScene";
 import { createRng, randomBetween, type RngFunction } from "../utils/random";
 import {
+  FROG_ATTENTION_SECONDS,
+  FROG_COMBO_WINDOW_SECONDS,
   FROG_CROAK_AUDIO_URL,
   FROG_CROAK_CLIP_SECONDS,
   FROG_CROAK_VOLUME,
   FROG_JUMP_DURATION,
   FROG_JUMP_HEIGHT,
+  FROG_LANDING_RIPPLE_SECONDS,
+  FROG_LOW_POLY_COLORS,
   FROG_RANDOM_ACTION_MIN_SECONDS,
   FROG_RANDOM_ACTION_VARIATION_SECONDS,
+  FROG_TRICK_DURATION_SECONDS,
   LILY_WAVE_AMPLITUDE,
   LILY_WAVE_FREQUENCY,
   LILY_WAVE_TIME_SCALE,
@@ -33,17 +38,6 @@ const scheduleNextAction = (rng: RngFunction) =>
     FROG_RANDOM_ACTION_MIN_SECONDS,
     FROG_RANDOM_ACTION_MIN_SECONDS + FROG_RANDOM_ACTION_VARIATION_SECONDS
   );
-
-const FROG_COMBO_WINDOW_SECONDS = 1.2;
-const FROG_TRICK_DURATION_SECONDS = 0.95;
-const FROG_ATTENTION_SECONDS = 2.8;
-const FROG_LANDING_RIPPLE_SECONDS = 0.65;
-const FROG_LOW_POLY_COLORS = {
-  body: "#294b2f",
-  back: "#19341f",
-  belly: "#6f8a55",
-  accent: "#0f2416",
-};
 
 const applyLowPolyFrogMaterial = (model: THREE.Object3D) => {
   let meshIndex = 0;

--- a/src/constants/waterPlants.ts
+++ b/src/constants/waterPlants.ts
@@ -63,6 +63,20 @@ export const FROG_CROAK_AUDIO_URL =
   "https://upload.wikimedia.org/wikipedia/commons/0/0c/Buergeria_buergeri.ogg";
 export const FROG_CROAK_CLIP_SECONDS = 2.4;
 
+// カエルのインタラクション挙動
+export const FROG_COMBO_WINDOW_SECONDS = 1.2;
+export const FROG_TRICK_DURATION_SECONDS = 0.95;
+export const FROG_ATTENTION_SECONDS = 2.8;
+export const FROG_LANDING_RIPPLE_SECONDS = 0.65;
+
+// カエルのローポリ配色
+export const FROG_LOW_POLY_COLORS = {
+  body: "#294b2f",
+  back: "#19341f",
+  belly: "#6f8a55",
+  accent: "#0f2416",
+} as const;
+
 // 水面の波の設定
 export const WATER_HEIGHT_BASE = 8;
 export const WATER_HEIGHT_AMPLITUDE = 0.5;


### PR DESCRIPTION
## 概要

`Frog.tsx` にローカル定義されていたインタラクション挙動の秒数定数とローポリ配色を、既存のカエル定数が集まる `src/constants/waterPlants.ts` へ移設しました。feature.md の「マジックナンバーを定数化」方針および `#185` `#186` の流儀に沿った整理です。**視覚・挙動は不変**です。

## 変更点

- `src/constants/waterPlants.ts`: `FROG_COMBO_WINDOW_SECONDS` / `FROG_TRICK_DURATION_SECONDS` / `FROG_ATTENTION_SECONDS` / `FROG_LANDING_RIPPLE_SECONDS` / `FROG_LOW_POLY_COLORS` を追加
- `src/components/Frog.tsx`: 上記のローカル定義を削除し import に置換

## 検証

- `npx tsc --noEmit` ✅ / `npm run lint` ✅ / `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)