### PR TITLE
improve: 魚の受光表現を昼夜に連動させる

### DIFF
--- a/src/components/FishManager.tsx
+++ b/src/components/FishManager.tsx
@@ -59,11 +59,12 @@ import {
 interface FishManagerProps {
   weather: WeatherSnapshot;
   waterSignal: number;
+  isDay: boolean;
 }
 
 const WATER_REACTION_SECONDS = 2.2;
 
-const FishManager: React.FC<FishManagerProps> = ({ weather, waterSignal }) => {
+const FishManager: React.FC<FishManagerProps> = ({ weather, waterSignal, isDay }) => {
   const { season } = useSeason();
   const rainIntensity = getRainIntensity(weather);
   const cloudIntensity = getCloudIntensity(weather);
@@ -142,7 +143,7 @@ const FishManager: React.FC<FishManagerProps> = ({ weather, waterSignal }) => {
   // 晴天ほど水中に光が差し、背側の受光ハイライト・瞳のキャッチライトが
   // 強まり、水中影も締まる。3要素を同じ光量係数でまとめて更新する
   useEffect(() => {
-    const underwaterBrightness = getUnderwaterBrightness(rainIntensity, cloudIntensity);
+    const underwaterBrightness = getUnderwaterBrightness(rainIntensity, cloudIntensity, isDay);
     const weatherOpacityTargets: [THREE.Material, number, number][] = [
       [fishSheenMaterial, FISH_DORSAL_SHEEN_OPACITY_MIN, FISH_DORSAL_SHEEN_OPACITY_MAX],
       [fishShadowMaterial, FISH_UNDERBODY_SHADOW_OPACITY_MIN, FISH_UNDERBODY_SHADOW_OPACITY_MAX],
@@ -156,6 +157,7 @@ const FishManager: React.FC<FishManagerProps> = ({ weather, waterSignal }) => {
     fishEyeHighlightMaterial,
     fishShadowMaterial,
     fishSheenMaterial,
+    isDay,
     rainIntensity,
   ]);
 

--- a/src/components/SceneCanvas.tsx
+++ b/src/components/SceneCanvas.tsx
@@ -183,7 +183,7 @@ const SceneCanvas = ({
       <MemoizedSundialBase />
 
       <Suspense fallback={null}>
-        <MemoizedFishManager weather={weather} waterSignal={waterSignal} />
+        <MemoizedFishManager weather={weather} waterSignal={waterSignal} isDay={isDay} />
       </Suspense>
       <Suspense fallback={null}>
         <WaterPlantsLarge />

--- a/src/fish/visualDetails.ts
+++ b/src/fish/visualDetails.ts
@@ -38,11 +38,17 @@ export const FLATFISH_DORSAL_SHEEN_POSITION: [number, number, number] = [0, 0.01
 export const FISH_DORSAL_SHEEN_OPACITY_MIN = 0.05;
 export const FISH_DORSAL_SHEEN_OPACITY_MAX = 0.14;
 
-/** 晴天ほど1に近づく水中の明るさ係数を返す */
+// 夜は水中に差す光が弱まる係数（昼=1.0 に対する夜の倍率）
+export const FISH_NIGHT_LIGHT_FACTOR = 0.35;
+
+/** 天候と昼夜から、晴天日中ほど1に近づく水中の明るさ係数を返す */
 export const getUnderwaterBrightness = (
   rainIntensity: number,
-  cloudIntensity: number
-) => Math.max(0, 1 - rainIntensity * 0.6 - cloudIntensity * 0.3);
+  cloudIntensity: number,
+  isDay: boolean
+) =>
+  Math.max(0, 1 - rainIntensity * 0.6 - cloudIntensity * 0.3) *
+  (isDay ? 1 : FISH_NIGHT_LIGHT_FACTOR);
 
 export const getFishAccentBaseOpacity = (
   isFlatfish: boolean,


### PR DESCRIPTION
## 概要

天候連動の水中明るさ係数 (`getUnderwaterBrightness`) に **昼夜** を加えました。夜は `FISH_NIGHT_LIGHT_FACTOR` で減光し、背側ハイライト (#189) と瞳のキャッチライト (#192) が夜に落ち着き、水中影 (#190) も和らぎます。日中の晴天で最も光を受ける、自然な光量表現になります。

## 変更点

- `src/fish/visualDetails.ts`: `FISH_NIGHT_LIGHT_FACTOR` を追加し、`getUnderwaterBrightness(rain, cloud, isDay)` に昼夜引数を追加
- `src/components/FishManager.tsx`: `isDay` prop を受け取り明るさ係数に反映
- `src/components/SceneCanvas.tsx`: 既存の `isDay` を `FishManager` へ配線

## 検証

- `npx tsc --noEmit` ✅ / `npm run lint` ✅ / `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)