### PR TITLE
feat: add screenshot saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ React、TypeScript、Three.jsを使用した、季節の移り変わりを静か
   - 日時計（影の動き）
   - 漂流する瓶（クリックで季節×時間帯の便箋表示）
   - 風向きコンパス
+  - スクリーンショット保存（日時・季節ウォーターマーク付きPNG）
 - **3Dモデル統合**:
   - **魚**: カレイ（底生魚の動き：待機→瞬間移動）
   - **植物**: 蓮の葉（夏・波に連動）、水草
@@ -27,7 +28,7 @@ React、TypeScript、Three.jsを使用した、季節の移り変わりを静か
 ## 技術スタック
 
 - **フロントエンド**: React 19 + TypeScript
-- **ビルドツール**: Vite 7
+- **ビルドツール**: Vite 8
 - **3D描画**: Three.js + @react-three/fiber + @react-three/drei
 - **物理エンジン**: @react-three/rapier
 - **デザインシステム**: トークンベースのスタイリング (tokens.ts)
@@ -113,8 +114,8 @@ src/
 │   ├── waterPlants.ts           # 水草・蓮の葉定数
 │   ├── rocks.ts                 # 岩の配置定数
 │   ├── stars.ts                 # 星空の定数
-│   └── sundial.ts               # 日時計の定数
-│   └── core/                 # アプリ全体の基礎定数（時間・システム色など）
+│   ├── sundial.ts               # 日時計の定数
+│   └── core/                    # アプリ全体の基礎定数（時間・システム色など）
 └── assets/                  # 静的資産（R2アップロード対象）
     ├── cc0____yellow_striped_flounder.glb       # カレイ3Dモデル
     ├── cc0__deep_autumn__5k_followers_milestone.glb  # 落ち葉3Dモデル

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, memo, useState, useEffect, useCallback } from "react";
+import React, { useMemo, memo, useState, useEffect, useCallback, useRef } from "react";
 
 import { SeasonProvider, TimeProvider, useDayPeriod } from "./contexts";
 import WindDirectionDisplay from "./components/WindDirectionDisplay";
@@ -62,6 +62,7 @@ const AppContent = () => {
   const [loadingProgress, setLoadingProgress] = useState(0);
   const [loadingText, setLoadingText] = useState("初期化中...");
   const [waterSignal, setWaterSignal] = useState(0);
+  const screenshotCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const performanceMonitorEnabled = useMemo(isPerformanceMonitorRequested, []);
   const isLoading = !(assetsLoaded && minDelayElapsed);
 
@@ -108,6 +109,10 @@ const AppContent = () => {
     setWaterSignal((signal) => signal + 1);
   }, [uxHints]);
 
+  const handleCanvasReady = useCallback((canvas: HTMLCanvasElement | null) => {
+    screenshotCanvasRef.current = canvas;
+  }, []);
+
   const appStyle: AppStyle = {
     "--app-background-color": backgroundColor,
   };
@@ -133,6 +138,7 @@ const AppContent = () => {
         waterSignal={waterSignal}
         onAssetsLoaded={handleAssetsLoaded}
         onBottleMessageRead={handleBottleMessageRead}
+        onCanvasReady={handleCanvasReady}
         onProgress={handleProgress}
         onWaterInteract={handleWaterInteract}
       />
@@ -149,6 +155,7 @@ const AppContent = () => {
         onReopenHints={!isLoading ? uxHints.reopenHints : undefined}
         onPanelOpened={uxHints.markPanelOpened}
         onAmbientToggle={uxHints.markAmbientToggled}
+        screenshotCanvasRef={screenshotCanvasRef}
       />
       {/* 風向きコンパス - ローディング完了後のみ表示 */}
       {!isLoading && (

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -12,6 +12,10 @@ interface LoaderProps {
 }
 
 const Loader = ({ progress = 0, loadingText = "読み込み中...", isExiting = false }: LoaderProps) => {
+  const clampedProgress = Number.isFinite(progress)
+    ? Math.min(100, Math.max(0, progress))
+    : 0;
+
   // 4匹の蛍 - それぞれ独立した経路を持つ
   const fireflies = [
     { delay: 0, x: [0, 30, -20, 10, 0], y: [0, -25, -15, -30, 0], duration: 4 },
@@ -77,7 +81,7 @@ const Loader = ({ progress = 0, loadingText = "読み込み中...", isExiting = 
         <div className={styles.progressContainer}>
           {/* 進捗パーセンテージ */}
           <div className={styles.percentage}>
-            {Math.round(progress)}%
+            {Math.round(clampedProgress)}%
           </div>
 
           {/* ローディングテキスト */}
@@ -89,7 +93,7 @@ const Loader = ({ progress = 0, loadingText = "読み込み中...", isExiting = 
           <div className={styles.progressBar}>
             <div
               className={styles.progressBarFill}
-              style={{ width: `${progress}%` }}
+              style={{ width: `${clampedProgress}%` }}
             />
           </div>
         </div>

--- a/src/components/SceneCanvas.tsx
+++ b/src/components/SceneCanvas.tsx
@@ -58,7 +58,10 @@ const LoadingTracker = ({ onLoaded, onProgress }: LoadingTrackerProps) => {
 
   useEffect(() => {
     if (active) {
-      const percentComplete = (loaded / total) * 100;
+      const percentComplete =
+        total > 0
+          ? Math.min(100, Math.max(0, (loaded / total) * 100))
+          : Math.min(100, Math.max(0, progress));
       const text = `3Dモデルを読み込み中... (${loaded}/${total})`;
       onProgress(percentComplete, text);
     } else {
@@ -82,6 +85,7 @@ interface SceneCanvasProps {
   waterSignal: number;
   onAssetsLoaded: () => void;
   onBottleMessageRead: () => void;
+  onCanvasReady: (canvas: HTMLCanvasElement | null) => void;
   onProgress: (progress: number, loadingText: string) => void;
   onWaterInteract: () => void;
 }
@@ -98,6 +102,7 @@ const SceneCanvas = ({
   waterSignal,
   onAssetsLoaded,
   onBottleMessageRead,
+  onCanvasReady,
   onProgress,
   onWaterInteract,
 }: SceneCanvasProps) => {
@@ -119,6 +124,7 @@ const SceneCanvas = ({
       powerPreference: "high-performance",
       alpha: false,
       stencil: false,
+      preserveDrawingBuffer: true,
     }),
     [isMobile]
   );
@@ -135,6 +141,7 @@ const SceneCanvas = ({
       dpr={canvasDpr}
       frameloop="always"
       performance={{ min: 0.5 }}
+      onCreated={({ gl }) => onCanvasReady(gl.domElement)}
     >
       <LoadingTracker onLoaded={onAssetsLoaded} onProgress={onProgress} />
       {!isDay && (

--- a/src/components/ScreenshotButton.tsx
+++ b/src/components/ScreenshotButton.tsx
@@ -1,0 +1,199 @@
+import { useState, type RefObject } from "react";
+
+import { useClockTime, useSeason } from "@/contexts";
+import { tokens } from "@/styles/tokens";
+
+interface ScreenshotButtonProps {
+  canvasRef: RefObject<HTMLCanvasElement | null>;
+  isMobile: boolean;
+}
+
+const seasonLabels = {
+  spring: "春",
+  summer: "夏",
+  autumn: "秋",
+  winter: "冬",
+} as const;
+
+const formatNumber = (value: number) => value.toString().padStart(2, "0");
+
+const getJapanDateParts = () => {
+  const formatter = new Intl.DateTimeFormat("ja-JP-u-ca-gregory", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const parts = formatter.formatToParts(new Date());
+
+  return {
+    year: parts.find((part) => part.type === "year")?.value ?? "0000",
+    month: parts.find((part) => part.type === "month")?.value ?? "00",
+    day: parts.find((part) => part.type === "day")?.value ?? "00",
+  };
+};
+
+const downloadBlob = (blob: Blob, fileName: string) => {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+};
+
+const buildScreenshotBlob = (
+  sourceCanvas: HTMLCanvasElement,
+  watermarkLines: string[]
+) =>
+  new Promise<Blob>((resolve, reject) => {
+    const width = sourceCanvas.width;
+    const height = sourceCanvas.height;
+
+    if (width === 0 || height === 0) {
+      reject(new Error("Canvas is not ready"));
+      return;
+    }
+
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+
+    const context = canvas.getContext("2d");
+    if (!context) {
+      reject(new Error("Canvas 2D context is not available"));
+      return;
+    }
+
+    context.drawImage(sourceCanvas, 0, 0, width, height);
+
+    const scale = Math.max(1, Math.min(width, height) / 720);
+    const padding = 18 * scale;
+    const lineHeight = 24 * scale;
+    const fontSize = 18 * scale;
+    const watermarkWidth = 320 * scale;
+    const watermarkHeight = padding * 2 + lineHeight * watermarkLines.length;
+    const x = width - watermarkWidth - padding;
+    const y = height - watermarkHeight - padding;
+
+    context.fillStyle = "rgba(19, 31, 44, 0.62)";
+    context.fillRect(x, y, watermarkWidth, watermarkHeight);
+    context.strokeStyle = "rgba(255, 255, 255, 0.22)";
+    context.strokeRect(x, y, watermarkWidth, watermarkHeight);
+    context.fillStyle = "rgba(255, 255, 255, 0.92)";
+    context.font = `${fontSize}px "Noto Serif JP", serif`;
+    context.textAlign = "left";
+    context.textBaseline = "top";
+
+    watermarkLines.forEach((line, index) => {
+      context.fillText(line, x + padding, y + padding + index * lineHeight);
+    });
+
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        reject(new Error("PNG conversion failed"));
+        return;
+      }
+
+      resolve(blob);
+    }, "image/png");
+  });
+
+export const ScreenshotButton = ({
+  canvasRef,
+  isMobile,
+}: ScreenshotButtonProps) => {
+  const { season } = useSeason();
+  const realTime = useClockTime();
+  const [isSaving, setIsSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const handleScreenshot = async () => {
+    const sourceCanvas = canvasRef.current;
+    if (!sourceCanvas || isSaving) {
+      return;
+    }
+
+    setIsSaving(true);
+    setErrorMessage(null);
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    try {
+      const { year, month, day } = getJapanDateParts();
+      const hour = formatNumber(realTime.hours);
+      const minute = formatNumber(realTime.minutes);
+      const second = formatNumber(realTime.seconds);
+      const timestamp = `${year}${month}${day}-${hour}${minute}${second}`;
+      const watermarkLines = [
+        "Mizube no Shiki",
+        `${year}/${month}/${day} ${hour}:${minute}:${second} JST`,
+        `季節: ${seasonLabels[season]}`,
+      ];
+
+      const blob = await buildScreenshotBlob(sourceCanvas, watermarkLines);
+      downloadBlob(blob, `mizube-no-shiki-${timestamp}.png`);
+    } catch (error) {
+      console.error("Screenshot capture failed", error);
+      setErrorMessage("保存できませんでした");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: isMobile ? "stretch" : "flex-end",
+        gap: tokens.spacing.xs,
+        width: isMobile ? "100%" : "auto",
+      }}
+    >
+      <button
+        onClick={handleScreenshot}
+        disabled={isSaving || !canvasRef.current}
+        aria-label="スクリーンショットを保存"
+        title="スクリーンショットを保存"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: isMobile ? "center" : "flex-start",
+          gap: tokens.spacing.xs,
+          fontFamily: tokens.typography.fontFamily.serif,
+          fontSize: isMobile ? "13px" : "14px",
+          fontWeight: 400,
+          padding: `${tokens.spacing.xs} ${tokens.spacing.md}`,
+          width: isMobile ? "100%" : "auto",
+          borderRadius: "999px",
+          border: "1px solid rgba(255, 255, 255, 0.22)",
+          color: "rgba(255, 255, 255, 0.86)",
+          background: "rgba(255, 255, 255, 0.08)",
+          cursor: isSaving ? "wait" : "pointer",
+          transition: tokens.transitions.base,
+          boxShadow: "0 4px 12px rgba(0, 0, 0, 0.2)",
+          opacity: canvasRef.current ? 1 : 0.65,
+        }}
+      >
+        <span aria-hidden="true">📷</span>
+        {isSaving ? "保存中" : "保存"}
+      </button>
+      {errorMessage && (
+        <span
+          role="status"
+          style={{
+            fontFamily: tokens.typography.fontFamily.serif,
+            fontSize: "12px",
+            color: "rgba(255, 255, 255, 0.78)",
+            textAlign: isMobile ? "center" : "right",
+          }}
+        >
+          {errorMessage}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/src/components/UI.tsx
+++ b/src/components/UI.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, type RefObject } from "react";
 import { useSeason } from "../contexts";
 import SimulationClock from "./SimulationClock";
 import { BottleJournalPanel } from "./BottleJournalPanel";
@@ -7,6 +7,7 @@ import { UiOpenButton } from "./UiOpenButton";
 import { FloatingUiHint } from "./FloatingUiHint";
 import { UiPanelCloseButton } from "./UiPanelCloseButton";
 import { InlineAmbientHint } from "./InlineAmbientHint";
+import { ScreenshotButton } from "./ScreenshotButton";
 import { tokens } from "@/styles/tokens";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useAmbientSound } from "@/hooks/useAmbientSound";
@@ -22,6 +23,7 @@ interface UIProps {
   onReopenHints?: () => void;
   onPanelOpened?: () => void;
   onAmbientToggle?: () => void;
+  screenshotCanvasRef?: RefObject<HTMLCanvasElement | null>;
 }
 
 /**
@@ -37,6 +39,7 @@ const UI: React.FC<UIProps> = ({
   onReopenHints,
   onPanelOpened,
   onAmbientToggle,
+  screenshotCanvasRef,
 }) => {
   const { season, setSeason } = useSeason();
   const isMobile = useIsMobile();
@@ -313,6 +316,13 @@ const UI: React.FC<UIProps> = ({
                 <span aria-hidden="true">✉</span>
                 最近の便り
               </button>
+
+              {screenshotCanvasRef && (
+                <ScreenshotButton
+                  canvasRef={screenshotCanvasRef}
+                  isMobile={isMobile}
+                />
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- Add a UI camera action for saving the current 3D canvas as a PNG
- Add JST date/time and current season watermark to exported images
- Clamp loader progress values to avoid invalid percentages
- Update README feature/docs consistency

## Test plan
- npm run lint
- npm run build
- Playwright direct capture check generated mizube-no-shiki-20260731-014538.png (133604 bytes)

## Notes
- npm run smoke:browser:strict currently fails locally because the dev server leaves the loader up when external R2/API requests return 502 or the Wrangler proxy is not running; screenshot generation itself was verified by triggering the button once the canvas existed.

Closes #29