### PR TITLE
chore: gate bundle visualizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "dev:wrangler": "concurrently \"vite --port 5173\" \"wrangler pages dev --port 8788 --proxy 5173\"",
     "build": "tsc -b && vite build",
+    "analyze": "BUILD_ANALYZE=1 npm run build",
     "lint": "eslint .",
     "preview": "vite preview",
     "smoke:browser": "node scripts/browser-smoke.mjs",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ const reactVendors = ["react", "react-dom"];
 const threeCoreVendors = ["three"];
 const reactThreeVendors = ["@react-three/fiber"];
 const matchesPackage = (id: string, pkg: string) => id.includes(`/node_modules/${pkg}/`);
+const shouldAnalyzeBundle = process.env.BUILD_ANALYZE === "1";
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -25,10 +26,11 @@ export default defineConfig({
   },
   plugins: [
     react(),
-    visualizer({
-      open: true, // Automatically open the report in the browser
-      filename: "dist/stats.html", // Output file
-    }),
+    shouldAnalyzeBundle &&
+      visualizer({
+        open: false,
+        filename: "dist/stats.html",
+      }),
   ],
   build: {
     minify: 'esbuild',


### PR DESCRIPTION
## Summary
- Keep the Rollup visualizer out of normal production builds
- Add `npm run analyze` for generating `dist/stats.html` on demand
- Disable automatic browser opening for analyzer output

## Test plan
- npm run lint
- npm run build
- npm run analyze